### PR TITLE
Nodetool rpc reply

### DIFF
--- a/priv/templates/simplenode.nodetool
+++ b/priv/templates/simplenode.nodetool
@@ -34,7 +34,7 @@ main(Args) ->
                 ok ->
                     ok;
                 {reply, Reply} ->
-                    io:format("~p\n", [Reply]);
+                    print_reply(Reply);
                 {badrpc, Reason} ->
                     io:format("RPC to ~p failed: ~p\n", [TargetNode, Reason]),
                     halt(1);
@@ -62,6 +62,15 @@ process_args(["-sname", TargetName | Rest], Acc, _) ->
     process_args(Rest, Acc, nodename(TargetName));
 process_args([Arg | Rest], Acc, Opts) ->
     process_args(Rest, [Arg | Acc], Opts).
+
+
+print_reply([]) ->
+    ok;
+print_reply([H|T]) ->
+    print_reply(H),
+    print_reply(T);
+print_reply(Reply) ->
+    io:format("~p\n", [Reply]).
 
 
 nodename(Name) ->


### PR DESCRIPTION
This commit allows nodetool to be a more generic command line tool to communicate with the remote node.

It does this by introducing a new clause into the rpc call.

To use this, a module on the remote node should be defined like:

% in module on remote node
-module(rebarctl).
-export([admin/1]).

admin([foo]) ->
     Reply = func_one(),
     {reply, Reply};
admin([bar]) ->
     Reply = func_two(),
     {reply, Reply};
admin(_) ->
     Reply = func_one(),
     {reply, "foo: Check foo status\nbar: Check bar status"}.

In the application command script then, the following bash case can be added:
# in bash control script

```
 admin)                                                                         
      $NODETOOL rpc rebarctl $@
     ;;                                                                           
```

The user can then call this like:

./bin/appscript admin foo

or

./bin/appscript admin bar
