### PR TITLE
Nested template variables.

### DIFF
--- a/src/rebar_templater.erl
+++ b/src/rebar_templater.erl
@@ -84,8 +84,8 @@ create(_Config, _) ->
     %% Load the template definition as is and get the list of variables the
     %% template requires.
     TemplateTerms = consult(load_file(Type, Template)),
-    case lists:keyfind(variables, 1, TemplateTerms) of
-        {variables, Vars} ->
+    case lists:keysearch(variables, 1, TemplateTerms) of
+        {value, {variables, Vars}} ->
             case parse_vars(Vars, dict:new()) of
                 {error, Entry} ->
                     Context0 = undefined,
@@ -104,8 +104,14 @@ create(_Config, _) ->
 
     %% For each variable, see if it's defined in global vars -- if it is, prefer that
     %% value over the defaults
-    Context = update_vars(dict:fetch_keys(Context0), Context0),
-    ?DEBUG("Template ~p context: ~p\n", [template_id(), dict:to_list(Context)]),
+    Context1 = update_vars(dict:fetch_keys(Context0), Context0),
+    ?DEBUG("Template ~p context: ~p\n", [template_id(), dict:to_list(Context1)]),
+
+    %% Handle variables that possibly include other variables in their
+    %% definition
+    Context = resolve_recursive_vars(dict:to_list(Context1), Context1),
+
+    ?DEBUG("Resolved Template ~p context: ~p\n", [template_id(), dict:to_list(Context1)]),
 
     %% Now, use our context to process the template definition -- this permits us to
     %% use variables within the definition for filenames.
@@ -204,6 +210,19 @@ update_vars([Key | Rest], Dict) ->
     Value = rebar_config:get_global(Key, dict:fetch(Key, Dict)),
     update_vars(Rest, dict:store(Key, Value, Dict)).
 
+
+%%
+%% Given a list of key value pairs, for each string value attempt to
+%% render it using Dict as the context.  Storing the result in Dict as Key.
+%%
+
+resolve_recursive_vars([], Dict) ->
+    Dict;
+resolve_recursive_vars([{Key, Value0} | Rest], Dict) when is_list(Value0) ->
+    Value = render(list_to_binary(Value0), Dict),
+    resolve_recursive_vars(Rest, dict:store(Key, Value, Dict));
+resolve_recursive_vars([_Pair | Rest], Dict) ->
+    resolve_recursive_vars(Rest, Dict).
 
 %%
 %% Given a string or binary, parse it into a list of terms, ala file:consult/0
@@ -319,4 +338,3 @@ execute_template([{variables, _} | Rest], TemplateType, TemplateName, Context, F
 execute_template([Other | Rest], TemplateType, TemplateName, Context, Force, ExistingFiles) ->
     ?WARN("Skipping unknown template instruction: ~p\n", [Other]),
     execute_template(Rest, TemplateType, TemplateName, Context, Force, ExistingFiles).
-


### PR DESCRIPTION
The commit 6c1cda6d27552e05ccd4d8a0f1168cde64a583c2 adds support for defining template variables of the following form:
    {variables, [{appid, "mochiwebapp"},
             {author, "Mochi Media dev@mochimedia.com"},
             {year, "2010"},
             {version, "0.1"},
             {port, 8080},
             {dest, "{{appid}}"}]}.

Where dest may be overridden on the commandline but will default to being the appid.  Mochiweb uses this so that we can create new projects from the template in a configurable directory.

So `./rebar create template=mochiwebapp dest=foo appid=bar`.  I thought about special casing dest but figured it might be generally useful to be able to nest templates vars.

However this patch only does one level of resolution so if 

```
{variables, [{foo, "{{bar}}"},
                {bar, "{{foo}}"}]}.
```

Then bar will end up being the literal string `{{bar}}` and foo the literal string `{{foo}}`
