### PR TITLE
New Default Application Template

### DIFF
--- a/priv/templates/standardapp.erl
+++ b/priv/templates/standardapp.erl
@@ -1,0 +1,45 @@
+%% @author Author <author@domain.com>
+%% @copyright YYYY Author
+
+%% @doc {{appid}} startup code
+
+-module({{appid}}).
+-author('Author').
+
+-export([start/0, start_link/0, stop/0]).
+
+%% ===================================================================
+%% Public API
+%% ===================================================================
+
+%% @spec start_link() -> {ok,Pid::pid()}
+%% @doc Starts the {{appid}} app for inclusion in a supervisor tree
+start_link() ->
+  ensure_started(crypto),
+  {{appid}}_sup:start_link().
+
+%% @spec start() -> ok
+%% @doc Start the {{appid}} server.
+start() ->
+  ensure_started(crypto),
+  application:start({{appid}}).
+
+%% @spec stop() -> ok
+%% @doc Stop the {{appid}} server.
+stop() ->
+  Res = application:stop({{appid}}),
+  application:stop(crypto),
+  Res.
+
+%% ===================================================================
+%% Internal Functions
+%% ===================================================================
+
+ensure_started(App) ->
+  case application:start(App) of
+    ok ->
+      ok;
+    { error, { already_started, App } } ->
+      ok
+  end.
+

--- a/priv/templates/standardapp.template
+++ b/priv/templates/standardapp.template
@@ -1,0 +1,7 @@
+{variables, [{appid, "myapp"}]}.
+{template, "simpleapp.app.src", "apps/{{appid}}/src/{{appid}}.app.src"}.
+{template, "simpleapp_app.erl", "apps/{{appid}}/src/{{appid}}_app.erl"}.
+{template, "simpleapp_sup.erl", "apps/{{appid}}/src/{{appid}}_sup.erl"}.
+{template, "standardapp.erl", "apps/{{appid}}/src/{{appid}}.erl"}.
+{template, "standardapp_rebar.config", "rebar.config"}.
+{template, "standardapp_Makefile", "Makefile"}.

--- a/priv/templates/standardapp_Makefile
+++ b/priv/templates/standardapp_Makefile
@@ -1,0 +1,23 @@
+ERL ?= erl
+PWD := $(shell pwd)
+
+.PHONY: deps
+.PHONY: start
+
+all: deps
+	@./rebar compile
+
+deps:
+	@./rebar get-deps
+
+clean:
+	@./rebar clean
+
+distclean: clean
+	@./rebar delete-deps
+
+docs:
+	@erl -noshell -run edoc_run application '{{appid}}' '"."' '[]'
+
+start: all
+	@erl -pa $(PWD)/apps/*/ebin/ $(PWD)/deps/*/ebin -boot start_sasl -s {{appid}}

--- a/priv/templates/standardapp_rebar.config
+++ b/priv/templates/standardapp_rebar.config
@@ -1,0 +1,2 @@
+%%-*- mode: erlang -*-
+{sub_dirs, ["apps/{{appid}}"]}.

--- a/src/rebar_templater.erl
+++ b/src/rebar_templater.erl
@@ -40,8 +40,8 @@
 %% ===================================================================
 
 'create-app'(Config, File) ->
-    %% Alias for create w/ template=simpleapp
-    rebar_config:set_global(template, "simpleapp"),
+    %% Alias for create w/ template=standardapp
+    rebar_config:set_global(template, "standardapp"),
     create(Config, File).
 
 'create-node'(Config, File) ->


### PR DESCRIPTION
Hi guys,

Same detail as before, new application template for creating apps with rebar. Commit history tidied up and start.sh replaced with a makefile target.

Cheers!
OJ

---

```
oj@nix ~/code/foo $ ./rebar create-app appid=bar
==> foo (create-app)
Writing apps/bar/src/bar.app.src
Writing apps/bar/src/bar_app.erl
Writing apps/bar/src/bar_sup.erl
Writing apps/bar/src/bar.erl
Writing rebar.config
Writing Makefile
oj@nix ~/code/foo $ make start
==> bar (get-deps)
==> foo (get-deps)
==> bar (compile)
Compiled src/bar.erl
Compiled src/bar_app.erl
Compiled src/bar_sup.erl
==> foo (compile)
Erlang R14A (erts-5.8) [source] [64-bit] [smp:2:2] [rq:2] [async-threads:0] [hipe] [kernel-poll:false]


=PROGRESS REPORT==== 10-Dec-2010::06:25:44 ===
          supervisor: {local,sasl_safe_sup}
             started: [{pid,<0.35.0>},
                       {name,alarm_handler},
                       {mfargs,{alarm_handler,start_link,[]}},
                       {restart_type,permanent},
                       {shutdown,2000},
                       {child_type,worker}]

=PROGRESS REPORT==== 10-Dec-2010::06:25:44 ===
          supervisor: {local,sasl_safe_sup}
             started: [{pid,<0.36.0>},
                       {name,overload},
                       {mfargs,{overload,start_link,[]}},
                       {restart_type,permanent},
                       {shutdown,2000},
                       {child_type,worker}]

=PROGRESS REPORT==== 10-Dec-2010::06:25:44 ===
          supervisor: {local,sasl_sup}
             started: [{pid,<0.34.0>},
                       {name,sasl_safe_sup},
                       {mfargs,
                           {supervisor,start_link,
                               [{local,sasl_safe_sup},sasl,safe]}},
                       {restart_type,permanent},
                       {shutdown,infinity},
                       {child_type,supervisor}]

=PROGRESS REPORT==== 10-Dec-2010::06:25:44 ===
          supervisor: {local,sasl_sup}
             started: [{pid,<0.37.0>},
                       {name,release_handler},
                       {mfargs,{release_handler,start_link,[]}},
                       {restart_type,permanent},
                       {shutdown,2000},
                       {child_type,worker}]

=PROGRESS REPORT==== 10-Dec-2010::06:25:44 ===
         application: sasl
          started_at: nonode@nohost
Eshell V5.8  (abort with ^G)
1> 
=PROGRESS REPORT==== 10-Dec-2010::06:25:44 ===
          supervisor: {local,crypto_sup}
             started: [{pid,<0.47.0>},
                       {name,crypto_server},
                       {mfargs,{crypto_server,start_link,[]}},
                       {restart_type,permanent},
                       {shutdown,2000},
                       {child_type,worker}]

=PROGRESS REPORT==== 10-Dec-2010::06:25:44 ===
         application: crypto
          started_at: nonode@nohost

=PROGRESS REPORT==== 10-Dec-2010::06:25:44 ===
         application: bar
          started_at: nonode@nohost

1> q().
ok
```
