### PR TITLE
Allowing to pass extra parameter to start the application under test

### DIFF
--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -91,6 +91,11 @@
 %% Whether to print coverage report to console. Default is `false'
 {cover_print_enabled, false}.
 
+%% == CT ==
+
+%% Option to pass extra parameters to launch Common Test suite
+{ct_extra_params, "-boot start_sasl -s myapp"}.
+
 %% == Dialyzer ==
 
 %% Options for running dialyzer

--- a/src/rebar_config.erl
+++ b/src/rebar_config.erl
@@ -31,7 +31,8 @@
          get_all/2,
          set/3,
          set_global/2, get_global/2,
-         is_verbose/0, get_jobs/0]).
+         is_verbose/0, get_jobs/0,
+         get_dir/1]).
 
 -include("rebar.hrl").
 
@@ -110,6 +111,9 @@ is_verbose() ->
 
 get_jobs() ->
     get_global(jobs, 3).
+
+get_dir(Config) ->
+    Config#config.dir.
 
 %% ===================================================================
 %% Internal functions


### PR DESCRIPTION
Hello,

Maybe I miss a point when building that patch, but that's the only way I found to start my Webmachine app under test before running the common test suites.

It adds support for the following option in rebar.config:
     {ct_extra_params, "-boot start_sasl -s myapp"}.

Comments are welcome !
