### PR TITLE
Cmcknight

### DIFF
--- a/src/rebar_protobuffs_compiler.erl
+++ b/src/rebar_protobuffs_compiler.erl
@@ -103,6 +103,7 @@ compile_each([{Proto, Beam, Hrl} | Rest]) ->
                     %% Compilation worked, but we need to move the .beam and .hrl file
                     %% into the ebin/ and include/ directories respectively
                     %% TODO: Protobuffs really needs to be better about this...sigh.
+                    ok = filelib:ensure_dir(filename:join("ebin","empty")),
                     [] = os:cmd(?FMT("mv ~s ebin", [Beam])),
                     ok = filelib:ensure_dir(filename:join("include", Hrl)),
                     [] = os:cmd(?FMT("mv ~s include", [Hrl])),


### PR DESCRIPTION
Corrected defect in rebar_protobuffs_compiler.erl that was causing ebin to be created as a file in the application directory if ebin did not already exist as a directory. The patch ensures the ebin directory is properly created by inserting the following at line 106 ahead of the "mv" statement:

```
ok = filelib:ensure_dir(filename:join("ebin","empty")),
```

Regards,

Chuck
