### PR TITLE
Add support for arch specific port_sources

### DIFF
--- a/src/rebar_port_compiler.erl
+++ b/src/rebar_port_compiler.erl
@@ -37,7 +37,9 @@
 
 %% Supported configuration variables:
 %%
-%% * port_sources - Erlang list of files and/or wildcard strings to be compiled
+%% * port_sources - Erlang list of files and/or wildcard strings to be compiled. Platform specific sources
+%%                  can be specified by enclosing a string in a tuple of the form {Regex, String} wherein
+%%                  Regex is a regular expression that is checked against the system architecture.
 %%
 %% * so_specs  - Erlang list of tuples of the form {"priv/so_name.so", ["c_src/object_file_name.o"]} useful for
 %%               building multiple *.so files.
@@ -133,6 +135,14 @@ clean(Config, AppFile) ->
 
 expand_sources([], Acc) ->
     Acc;
+expand_sources([{ArchRegex, Spec} | Rest], Acc) ->
+    case rebar_utils:is_arch(ArchRegex) of
+        true ->
+            Acc2 = filelib:wildcard(Spec) ++ Acc,
+            expand_sources(Rest, Acc2);
+        false ->
+            expand_sources(Rest, Acc)
+    end;
 expand_sources([Spec | Rest], Acc) ->
     Acc2 = filelib:wildcard(Spec) ++ Acc,
     expand_sources(Rest, Acc2).


### PR DESCRIPTION
This patch enables architecture specific port_sources to be specified using a {Regex, String} tuple. Eg:

```
{port_sources, [{"R14", ["c_src/*.c"]}]}.
```

If there's a more appropriate way to do this please let me know.

— Andrew
