### PR TITLE
Eunit controls

### DIFF
--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -86,15 +86,21 @@
 %% Primitive controls for eunit:test()
 %% See http://www.erlang.org/doc/apps/eunit/chapter.html#Control
 %%
+%% Supported controls:
+%% - {inparallel, Tests}, {inparallel, N, Tests}
+%% - {inorder, Tests}
+%% where Tests can be a list of
+%% - module names (atoms) or {module, Module}
+%% - {Module, Function} tuples
+%%
 %% Use '_' as a wildcard to include all remaining modules. This should always
 %% be used in the last control of the list
 %%
-%% Example 1: run foo_test, bar_test sequencially, then all the other modules
-%% in parallel:
-%% [{inorder, [foo_test, bar_test]}, {inparallel, '_'}]
+%% Example: run foo_test, {bar, bar_test} sequencially,
+%% then all the other tests in parallel:
+%% [{inorder, [foo_test, {bar, bar_test}]}, {inparallel, '_'}]
 %%
-%% Example 2: run bar:bar_test with a timeout of 10s:
-%% [{timeout, 10, [{bar, bar_test}]}]
+%% The 'timeout' control should be specified in a 'test generator', not here.
 {eunit_controls, []}
 
 %% Additional compile options for eunit. erl_opts from above is also used

--- a/src/rebar_eunit.erl
+++ b/src/rebar_eunit.erl
@@ -205,13 +205,10 @@ eunit_control({inparallel, N, Tests}, {Acc, Modules}) ->
 eunit_control({inorder, Tests}, {Acc, Modules}) ->
     {Included, Excluded} = recurse_controls(Tests, Modules),
     {[{inorder, Included} | Acc], Excluded};
-eunit_control({timeout, T, Tests}, {Acc, Modules}) ->
-    {Included, Excluded} = recurse_controls(Tests, Modules),
-    {[{timeout, T, Included} | Acc], Excluded};
 %% Some controls do not handle modules as input (eg: timeout)
 %% Allow to specify {Module, Function} and remember this particular test is
 %% performed
-eunit_control({M, F}, {Acc, Modules}) ->
+eunit_control({M, F}, {Acc, Modules}) when is_atom(M), is_atom(F) ->
     case lists:member(M, Modules) of
         true ->
             M_tests = eunit_data:get_module_tests(M),
@@ -227,10 +224,7 @@ eunit_control(Module, {Acc, Modules}) when is_atom(Module) ->
         _ -> {Acc, Modules}
     end;
 eunit_control({module, Module}, {Acc, Modules}) when is_atom(Module) ->
-    eunit_control(Module, {Acc, Modules});
-%% Allows application, Path, dir... Relevant in rebar context ?
-eunit_control(Other, {Acc, Modules})  ->
-    {Acc ++ [Other], Modules}.
+    eunit_control(Module, {Acc, Modules}).
 
 recurse_controls(Tests, Modules) when is_list(Tests) ->
     lists:foldl(fun eunit_control/2, {[], Modules}, Tests);

--- a/test/rebar_eunit_tests.erl
+++ b/test/rebar_eunit_tests.erl
@@ -45,11 +45,11 @@
 %% ====================================================================
 
 eunit_controls_test() ->
-    InOrder = {inorder, [bart, {timeout, 10, [homer]}]},
+    InOrder = {inorder, [bart, homer]},
     Parallel = {inparallel, [foo, bar]},
     Modules = [foo, bar, baz, homer],
     Result = rebar_eunit:eunit_controls([InOrder, Parallel], Modules),
-    Expected = [{inorder, [{timeout, 10, [homer]}]},
+    Expected = [{inorder, [homer]},
                 {inparallel, [foo,bar]}, baz],
     ?assertEqual(Expected, Result).
 
@@ -62,10 +62,10 @@ eunit_controls_wildcard_test() ->
 
 eunit_controls_mod_fun_test() ->
     Test = {?MODULE, eunit_controls_mod_fun_test},
-    Controls = [{inparallel, [{timeout, 10, [Test]}]}],
+    Controls = [{inparallel, [Test]}],
     Modules = [?MODULE, bar],
     Result = rebar_eunit:eunit_controls(Controls, Modules),
-    [{inparallel, [{timeout, 10, [Test]}]}, bar | Rest] = Result,
+    [{inparallel, [Test]}, bar | Rest] = Result,
     ?assert(length(Rest) > 1),
     ?assertNot(lists:member(Test, Rest)),
     ?assertEqual(true, lists:all(fun(X) -> is_tuple(X) end, Rest)).


### PR DESCRIPTION
Tried to find a way to use the primitive controls in eunit/rebar

The main goal was to use the {inparallel, [...]} directive to reduce test time, but this patch allows other controls (such as {timeout, ...}, {inorder,...} to run.

This feature is triggered by a new rebar.config parameter: eunit_controls.
This is a list of primitives to apply, with '_' as a wildcard.

Example 1: run foo_test, bar_test sequencially, then all the other modules in parallel:
[{inorder, [foo_test, bar_test]}, {inparallel, '_'}]

Example 2: run foo_test and bar_test with a timeout of 10s in parallel with 3 threads:
[{parallel, 3, [{timeout, 10, [foo_test, bar_test]}]}]

Modules not listed in the controls (explicit name or '_') are appended at the end of the list, keeping current behaviour.

I thought about a hint in the test file itself to know if a test can pass in parallel. However, I think it really depends on the context (aka which tests run at the same time), so this is not really something that should be hard-coded.
