### PR TITLE
Common Test Spec Support

### DIFF
--- a/include/rebar.hrl
+++ b/include/rebar.hrl
@@ -15,4 +15,3 @@
 -define(ERROR(Str, Args), rebar_log:log(error, Str, Args)).
 
 -define(FMT(Str, Args), lists:flatten(io_lib:format(Str, Args))).
-

--- a/inttest/ct2/ct2_rt.erl
+++ b/inttest/ct2/ct2_rt.erl
@@ -1,0 +1,26 @@
+-module(ct2_rt).
+
+-compile(export_all).
+
+
+files() ->
+    [{create, "ebin/foo.app", app(foo)},
+     {copy, "../../rebar", "rebar"},
+     {copy, "foo.test.spec", "test/foo.test.spec"},
+     {copy, "foo_SUITE.erl", "test/foo_SUITE.erl"}].
+
+run(_Dir) ->
+    {ok, _} = retest:sh("./rebar compile ct -v"),
+    ok.
+
+%%
+%% Generate the contents of a simple .app file
+%%
+app(Name) ->
+    App = {application, Name,
+           [{description, atom_to_list(Name)},
+            {vsn, "1"},
+            {modules, []},
+            {registered, []},
+            {applications, [kernel, stdlib]}]},
+    io_lib:format("~p.\n", [App]).

--- a/inttest/ct2/foo.test.spec
+++ b/inttest/ct2/foo.test.spec
@@ -1,0 +1,1 @@
+{suites, "test", all}.

--- a/inttest/ct2/foo_SUITE.erl
+++ b/inttest/ct2/foo_SUITE.erl
@@ -1,0 +1,10 @@
+-module(foo_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+
+-compile(export_all).
+
+all() -> [foo].
+
+foo(Config) ->
+    io:format("Test: ~p\n", [Config]).


### PR DESCRIPTION
This change adds support for executing ct test runs based on test specificiations, which was missing previously. This is a resubmission of a previous (closed) pull request from nebularis/rebar.

The `rebar_ct` module now looks for any number of files with a name ending in `test.spec` and if it finds one or more, passes these after the `-spec` argument to ct_run instead of explicitly configuring the config, user config and coverage config variables.

When no specifications are found, then the module behaves as it did before this change, and both the ct1 and (new) ct2 integration tests appear to show this is a backwards compatible patch.
