### PR TITLE
Fix macros

### DIFF
--- a/include/rebar.hrl
+++ b/include/rebar.hrl
@@ -16,3 +16,10 @@
 
 -define(FMT(Str, Args), lists:flatten(io_lib:format(Str, Args))).
 
+-ifndef(BUILD_TIME).
+-define(BUILD_TIME, "undefined").
+-endif.
+
+-ifndef(VCS_INFO).
+-define(VCS_INFO, "undefined").
+-endif.

--- a/src/rebar_core.erl
+++ b/src/rebar_core.erl
@@ -34,14 +34,6 @@
 -include("rebar.hrl").
 
 
--ifndef(BUILD_TIME).
--define(BUILD_TIME, "undefined").
--endif.
-
--ifndef(VCS_INFO).
--define(VCS_INFO, "undefined").
--endif.
-
 %% ===================================================================
 %% Public API
 %% ===================================================================


### PR DESCRIPTION
Please consider this patch. The `BUILD_TIME` and `VCS_INFO` macros caused eunit compilation to fail prior to this minor change. 
