### PR TITLE
Fix Issue 500 (and subsume issue 763)

### DIFF
--- a/src/rebar_deps.erl
+++ b/src/rebar_deps.erl
@@ -244,6 +244,13 @@ is_app_available(App, VsnRegex, Path) ->
                           [App, VsnRegex, App, Vsn, Path]),
                     case re:run(Vsn, VsnRegex, [{capture, none}]) of
                         match ->
+                            %% we found this one and it's already installed 
+                            %% outside of our working area, so we'll leave it 
+                            %% alone from now on (e.g., not clean/remove it).
+                            case rebar_utils:is_outside_base_dir(Path) of
+                                true -> rebar_core:skip_dir(Path);
+                                _ -> ignored
+                            end,
                             {true, Path};
                         nomatch ->
                             ?WARN("~s has version ~p; requested regex was ~s\n",

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -29,6 +29,9 @@
 -export([get_cwd/0,
          is_arch/1,
          get_arch/0,
+         get_temp_dir/0,
+         get_temp_filename/0,
+         is_outside_base_dir/1,
          sh/2,
          find_files/2,
          now_str/0,
@@ -62,6 +65,22 @@ get_arch() ->
     Words = integer_to_list(8 * erlang:system_info(wordsize)),
     erlang:system_info(otp_release) ++ "-"
         ++ erlang:system_info(system_architecture) ++ "-" ++ Words.
+
+get_temp_dir() ->
+    case os:getenv("TEMP") of
+      false ->
+          "/tmp";
+      Val -> 
+          Val
+    end.
+
+get_temp_filename() ->
+    filename:join(get_temp_dir(), 
+        io_lib:format("~p", [erlang:phash2(make_ref())])).
+
+is_outside_base_dir(Path) ->
+    BaseDir = rebar_config:get_global(base_dir, []),
+    not(lists:prefix(BaseDir, Path)).
 
 %%
 %% Options = [Option] -- defaults to [use_stdout, abort_on_error]


### PR DESCRIPTION
Fix issue 500

This change resolves issue 500, by preventing
destructive commands (such as clean, compile
and create/template) from running inside any
dependency directory that is outside of the
current project base_dir.

The rationale for this alteration is that any
dependency installed outside of the base_dir,
was likely installed by some other means and
is therefore outside of rebar's area of
responsibility.

This fix also subsumes issue 763, which limits
the scope of the problem to the code:lib_dir
only. Whilst this is clearly a problem, it is
the author's view that any dependency that has
not been installed by rebar within a project
directory, should not be affected by its use.
