### PR TITLE
Implicit git head

### DIFF
--- a/src/rebar_deps.erl
+++ b/src/rebar_deps.erl
@@ -299,6 +299,10 @@ download_source(AppDir, {hg, Url, Rev}) ->
     rebar_utils:sh(?FMT("hg clone -U ~s ~s", [Url, filename:basename(AppDir)]),
                    [{cd, filename:dirname(AppDir)}]),
     rebar_utils:sh(?FMT("hg update ~s", [Rev]), [{cd, AppDir}]);
+download_source(AppDir, {git, Url}) ->
+    download_source({git, Url, "HEAD"});
+download_source(AppDir, {git, Url, ""}) ->
+    download_source({git, Url, "HEAD"});
 download_source(AppDir, {git, Url, {branch, Branch}}) ->
     ok = filelib:ensure_dir(AppDir),
     rebar_utils:sh(?FMT("git clone -n ~s ~s", [Url, filename:basename(AppDir)]),
@@ -339,6 +343,10 @@ update_source(Dep) ->
             Dep
     end.
 
+update_source(AppDir, {git, Url}) ->
+    update_source({git, Url, "HEAD"});
+update_source(AppDir, {git, Url, ""}) ->
+    update_source({git, Url, "HEAD"});
 update_source(AppDir, {git, _Url, {branch, Branch}}) ->
     ShOpts = [{cd, AppDir}],
     rebar_utils:sh("git fetch origin", ShOpts),


### PR DESCRIPTION
Historically VC specs of the form:

```
{git, Url, ""}
```

Have allowed us (mochi) to track the default branch of a repository regardless of if that default branch is master, and without hard coding the default branch into our VC spec.

This worked up until the latest line of update-deps changes.  This has been preventing mochi from upgrading to the latest rebar for a few weeks now.  My patch adds to extra clauses to download_source and update_source which attempt to fix this.

One restores this functionality by turning
    {git, Url, ""}

into
    {git, Url, "HEAD"}

The other adds a new 2 arity version of of
    {git, Url}

which also gets turned into
    {git, Url, "HEAD"}
