### PR TITLE
Convert entries in the code path to absolute paths

### DIFF
--- a/src/rebar_core.erl
+++ b/src/rebar_core.erl
@@ -76,6 +76,10 @@ process_commands([Command | Rest]) ->
     lists:foreach(fun (D) -> erlang:erase({skip_dir, D}) end, skip_dirs()),
     Operations = erlang:get(operations),
 
+    %% Convert the code path so that all the entries are absolute paths.
+    %% If not, code:set_path() may choke on invalid relative paths when trying
+    %% to restore the code path from inside a subdirectory.
+    true = rebar_utils:expand_code_path(),
     _ = process_dir(rebar_utils:get_cwd(), rebar_config:new(),
                     Command, sets:new()),
     case erlang:get(operations) of

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -38,7 +38,8 @@
          abort/2,
          escript_foldl/3,
          find_executable/1,
-         prop_check/3]).
+         prop_check/3,
+         expand_code_path/0]).
 
 -include("rebar.hrl").
 
@@ -155,6 +156,14 @@ find_executable(Name) ->
 %% Helper function for checking values and aborting when needed
 prop_check(true, _, _) -> true;
 prop_check(false, Msg, Args) -> ?ABORT(Msg, Args).
+
+%% Convert all the entries in the code path to absolute paths.
+expand_code_path() ->
+    CodePath = lists:foldl(fun (Path, Acc) ->
+                                   [filename:absname(Path) | Acc]
+                           end, [], code:get_path()),
+    code:set_path(lists:reverse(CodePath)).
+
 
 %% ====================================================================
 %% Internal functions


### PR DESCRIPTION
The current version of _rebar_ will exit with `{error,bad_directory}` when trying to restore the code path after it has finished working on a subdirectory if there are invalid relative paths in it. When this happens, an exception is thrown because of a bad match in the last line of `rebar_erlc_compiler:doterl_compile/3`:

```
true = code:set_path(CurrPath),
```

The problem can be easily replicated by creating a `.erlang` file in the project's directory with a relative path that is not valid inside one of the declared dependencies.

e.g. Create the `lib/subproj/ebin` directory and add it to the code path in a `.erlang` file on your project with the following contents: 

```
code:add_pathz("lib/subproj/ebin").
```

Now try compiling a project that has a dependency declared in the `rebar.config` file. After running:

```
$ rebar compile
```

You should see something like:

```
ERROR: compile failed while processing /home/jcomellas/devel/a5/deps/astomp: {'EXIT',{{badmatch,{error,bad_directory}},
         [{rebar_erlc_compiler,doterl_compile,3},
          {rebar_erlc_compiler,compile,2},
          {rebar_core,run_modules,4},
          {rebar_core,execute,4},
          {rebar_core,process_dir,4},
          {rebar_core,process_each,5},
          {rebar_core,process_dir,4},
          {rebar_core,process_commands,1}]}}
```
