### PR TITLE
Pass extra parameters to common test 

### DIFF
--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -75,6 +75,11 @@
 %% Whether to print coverage report to console. Default is `false'
 {cover_print_enabled, false}.
 
+%% == CT ==
+
+%% Option to pass extra parameters when launching Common Test
+{ct_extra_params, "-boot start_sasl -s myapp"}.
+
 %% == Dialyzer ==
 
 %% Options for running dialyzer

--- a/src/rebar_ct.erl
+++ b/src/rebar_ct.erl
@@ -145,15 +145,17 @@ make_cmd(TestDir, Config) ->
         undefined ->
             ?FMT("erl " % should we expand ERL_PATH?
                        " -noshell -pa ~s ~s"
-                       " -s ct_run script_start -s erlang halt"
                        " -name test@~s"
                        " -logdir \"~s\""
-                       " -env TEST_DIR \"~s\"",
+                       " -env TEST_DIR \"~s\""
+                       " ~s"
+                       " -s ct_run script_start -s erlang halt",
                        [CodePathString,
                         Include,
                         net_adm:localhost(),
                         LogDir,
-                        filename:join(Cwd, TestDir)]) ++
+                        filename:join(Cwd, TestDir),
+                        get_extra_params(Config)]) ++
                 get_cover_config(Config, Cwd) ++
                 get_ct_config_file(TestDir) ++
                 get_config_file(TestDir) ++
@@ -162,19 +164,24 @@ make_cmd(TestDir, Config) ->
         SpecFlags ->
             ?FMT("erl " % should we expand ERL_PATH?
                        " -noshell -pa ~s ~s"
-                       " -s ct_run script_start -s erlang halt"
                        " -name test@~s"
                        " -logdir \"~s\""
-                       " -env TEST_DIR \"~s\"",
+                       " -env TEST_DIR \"~s\""
+                       " ~s"
+                       " -s ct_run script_start -s erlang halt",
                        [CodePathString,
                         Include,
                         net_adm:localhost(),
                         LogDir,
-                        filename:join(Cwd, TestDir)]) ++
+                        filename:join(Cwd, TestDir),
+                        get_extra_params(Config)]) ++
                 SpecFlags ++ get_cover_config(Config, Cwd)
     end,
     RawLog = filename:join(LogDir, "raw.log"),
     {Cmd, RawLog}.
+
+get_extra_params(Config) ->
+    rebar_config:get_local(Config, ct_extra_params, "").
 
 get_ct_specs(Cwd) ->
     case collect_glob(Cwd, ".*\.test\.spec\$") of


### PR DESCRIPTION
This patch adds a `ct_extra_params` option to rebar.config, the value
of which is appended to the shell command when executing common test.
