### PR TITLE
common_test include option prefix should be "-include"

### DIFF
--- a/src/rebar_ct.erl
+++ b/src/rebar_ct.erl
@@ -127,7 +127,7 @@ make_cmd(TestDir, Config) ->
     IncludeDir = filename:join(Cwd, "include"),
     case filelib:is_dir(IncludeDir) of
         true ->
-            Include = " -I \"" ++ IncludeDir ++ "\"";
+            Include = " -include \"" ++ IncludeDir ++ "\"";
         false ->
             Include = ""
     end,


### PR DESCRIPTION
When I run common_test via rebar, it can not find *.hrl under $ROOT/include/ .

Error message extracted:
    Recompile: kai_config_SUITE
    ./kai_config_SUITE.erl:17: can't find include file "kai.hrl"
    ./kai_config_SUITE.erl:18: can't find include file "kai_test.hrl"

kai_config_SUITE.erl is in $ROOT/test/, and kai.hrl is in $ROOT/include/

I don't know much about ct_run:script_start, but the module probably use "-include" instead of "-I" as same as ct_run script.
This patch change "-I" to "-include" in erl arguments which execute ct_run:script_start.

My enviroment:
- My project has standard layout (https://github.com/shino/kai/tree/feature/rebar, feature/rebar branch)
- Erlang/OTP R14B02 (64 bit, not hipe)
- Mac OS X (10.6.6)
