### PR TITLE
Fix bug: xref should be stopped after being run

### DIFF
--- a/src/rebar_xref.erl
+++ b/src/rebar_xref.erl
@@ -79,6 +79,9 @@ xref(Config, _) ->
     %% Restore the original code path
     true = code:set_path(OrigPath),
 
+    %% Stop xref
+    xref:stop(xref),
+
     ok.
 
 %% ===================================================================


### PR DESCRIPTION
Xref not being stopped caused a crash in subsequent xref runs.
