### PR TITLE
Add fail_on_warning option to xref command

### DIFF
--- a/src/rebar_xref.erl
+++ b/src/rebar_xref.erl
@@ -103,7 +103,7 @@ xref(Config, _) ->
 %% Internal functions
 %% ===================================================================
 
-check_exports_not_used(Config) ->
+check_exports_not_used(_Config) ->
     {ok, UnusedExports0} = xref:analyze(xref, exports_not_used),
     UnusedExports = filter_away_ignored(UnusedExports0),
 
@@ -111,7 +111,7 @@ check_exports_not_used(Config) ->
     display_mfas(UnusedExports, "is unused export (Xref)"),
     UnusedExports =:= [].
 
-check_undefined_function_calls(Config) ->
+check_undefined_function_calls(_Config) ->
     {ok, UndefinedCalls0} = xref:analyze(xref, undefined_function_calls),
     UndefinedCalls =
         [{find_mfa_source(Caller), format_fa(Caller), format_mfa(Target)} ||


### PR DESCRIPTION
The compile command has fail_on_warning option.
This patch adds the same option to xref command.
