### PR TITLE
Protobuf search src_dirs and protobuf_dirs

### DIFF
--- a/src/rebar_protobuffs_compiler.erl
+++ b/src/rebar_protobuffs_compiler.erl
@@ -36,9 +36,9 @@
 %% ===================================================================
 
 compile(Config, _AppFile) ->
-    SrcDirs=["src"] ++ rebar_config:get(Config,src_dirs,[]) ++ rebar_config:get(Config,protobuf_dirs,[]),
+    SrcDirs=["src"] ++ rebar_config:get(Config,src_dirs,[]),
     SrcFiles=lists:foldl(fun(D,A) -> 
-        A ++ filelib:wildcard( D ++ "/*.proto")
+        A ++ filelib:wildcard( filename:join([D,"*.proto"]))
     end,[],SrcDirs),
     case SrcFiles of
         [] ->


### PR DESCRIPTION
Protobuf compiler now searches src_dirs and protobuf_dirs for .proto files to compile
