### PR TITLE
check-plt should use ?ABORT for invalid and non up-to-date plt.

### DIFF
--- a/src/rebar_dialyzer.erl
+++ b/src/rebar_dialyzer.erl
@@ -119,7 +119,7 @@ dialyze(Config, File) ->
     end,
     ok.
 
-%% @doc Check whether the PLT is up-to-date (rebuilding it if not).
+%% @doc Check whether the PLT is up-to-date.
 -spec 'check-plt'(Config::rebar_config:config(), File::file:filename()) -> ok.
 'check-plt'(Config, File) ->
     Plt = existing_plt_path(Config, File),
@@ -128,10 +128,10 @@ dialyze(Config, File) ->
             ?CONSOLE("The PLT ~s is up-to-date~n", [Plt]);
         _ ->
             %% @todo Determine whether this is the correct summary.
-            ?CONSOLE("The PLT ~s is not up-to-date~n", [Plt])
+            ?ABORT("The PLT ~s is not up-to-date~n", [Plt])
     catch
         throw:{dialyzer_error, _Reason} ->
-            ?CONSOLE("The PLT ~s is not valid.~n", [Plt])
+            ?ABORT("The PLT ~s is not valid.~n", [Plt])
     end,
     ok.
 


### PR DESCRIPTION
When using ?ABORT check-plt will cause rebar to exit w/ a non-zero exit code allowing for the following construction.

```
rebar check-plt || rebar build-plt
```

Alternatively check-plt could be made to execute build-plt in both the cases but that may not be desirable as build-plt could take an extended period of time and check-plt is not really appropriately named to indicate that it forces a build.
