### PR TITLE
New eunit param skip_app, allow suite to be a comma seperated list

### DIFF
--- a/src/rebar_eunit.erl
+++ b/src/rebar_eunit.erl
@@ -59,9 +59,22 @@ eunit(Config, AppFile) ->
     %% of apps on which we want to run eunit
     case rebar_config:get_global(app, undefined) of
         undefined ->
-            %% No app parameter specified, run everything..
-            ok;
-
+            %% No app parameter specified, check the skip list..
+            case rebar_config:get_global(skip_app, undefined) of
+                undefined ->
+                    %% no skip list, run everything..
+                    ok;
+                SkipApps ->
+                    TargetApps = [list_to_atom(A) || A <- string:tokens(SkipApps, ",")],
+                    ThisApp = rebar_app_utils:app_name(AppFile),
+                    case lists:member(ThisApp, TargetApps) of
+                        false ->
+                            ok;
+                        true ->
+                            ?DEBUG("Skipping eunit on app: ~p\n", [ThisApp]),
+                            throw(ok)
+                    end
+            end;
         Apps ->
             TargetApps = [list_to_atom(A) || A <- string:tokens(Apps, ",")],
             ThisApp = rebar_app_utils:app_name(AppFile),
@@ -144,7 +157,7 @@ ebin_dir() ->
 
 perform_eunit(Config, Modules) ->
     %% suite defined, so only specify the module that relates to the
-    %% suite (if any)
+    %% suite (if any). Suite can be a comma seperated list of modules to run.
     Suite = rebar_config:get_global(suite, undefined),
     EunitOpts = get_eunit_opts(Config),
 
@@ -162,8 +175,8 @@ perform_eunit(Config, Modules) ->
 
 perform_eunit(EunitOpts, Modules, undefined) ->
     (catch eunit:test(Modules, EunitOpts));
-perform_eunit(EunitOpts, _Modules, Suite) ->
-    (catch eunit:test(list_to_atom(Suite), EunitOpts)).
+perform_eunit(EunitOpts, _Modules, Suites) ->
+    (catch eunit:test([list_to_atom(Suite) || Suite <- string:tokens(Suites, ",")], EunitOpts)).
 
 get_eunit_opts(Config) ->
     %% Enable verbose in eunit if so requested..
@@ -229,8 +242,9 @@ perform_cover(true, Config, BeamFiles, SrcModules) ->
 cover_analyze(_Config, [], _SrcModules) ->
     ok;
 cover_analyze(Config, Modules, SrcModules) ->
-    Suite = list_to_atom(rebar_config:get_global(suite, "")),
-    FilteredModules = [M || M <- Modules, M =/= Suite],
+    %% suite can be a comma seperated list of modules to test
+    Suite = [list_to_atom(Suite) || Suite <- string:tokens(rebar_config:get_global(suite, ""), ",")],
+    FilteredModules = [M || M <- Modules, lists:member(M, Suite)],
 
     %% Generate coverage info for all the cover-compiled modules
     Coverage = [cover_analyze_mod(M) || M <- FilteredModules],


### PR DESCRIPTION
This patch allows the 'suite' argument to eunit to be a comma separated
list of modules to test instead of being a single module. This allows
fine-grained testing when one test suite interferes with another and its
not clear which suite is causing the problem. It also lets you run the
test suite in a different order for a similar reason.

The other enhancement is to add a new eunit parameter; 'skip_app' which
like 'app' is a comma separated list of modules to skip testing on. This
parameter is only applied if the app parameter is not passed. Its
purpose is to avoid forcing you to specify all the apps to test if you
only want to skip a handful and there are many apps to test.
