### PR TITLE
Excluding analysis of apps from PLT directory

### DIFF
--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -86,7 +86,10 @@
 %% {plt, PltFile}
 %% 'src': run Dialyzer on the source files as in 'dialyzer --src'
 %% {warnings, [WarnOpts]}: turn on/off Dialyzer warnings
-{dialyzer_opts, [{plt, PltFile}, {warnings, [WarnOpts]}, src]}.
+%% {excluded_apps, [ExclApps]}: names of apps excluded
+%%   when building PTL
+{dialyzer_opts, [{plt, PltFile}, {warnings, [WarnOpts]}, src,
+                 {excluded_apps, [ExclApps]}]}.
 
 %% == Cleanup ==
 


### PR DESCRIPTION
When I was using rebar build-plt I got an error for a library I was using which did not have any debug info. Instead of worrying about rebuilding it I made a slight modification in rebar.config so that I can exclude an app if I so desire. Note that if I put all the libraries I use in excluded apps it complains so one library at least needs to be analyzed. 
