### PR TITLE
Added CFLAGS and DRV_CFLAGS  to port compilation command

### DIFF
--- a/src/rebar_port_compiler.erl
+++ b/src/rebar_port_compiler.erl
@@ -121,7 +121,8 @@ compile(Config, AppFile) ->
                       case needs_link(SoName, sets:to_list(Intersection)) of
                           true ->
                               rebar_utils:sh(
-                                ?FMT("$CC ~s $LDFLAGS $DRV_LDFLAGS -o ~s",
+                                ?FMT("$CC $CFLAGS $DRV_CFLAGS "
+                                     "~s $LDFLAGS $DRV_LDFLAGS -o ~s",
                                      [string:join(Bins, " "), SoName]),
                                 [{env, Env}]);
                           false ->


### PR DESCRIPTION
When compiling my erlang-bcrypt project (which uses a NIF), I get the following error due to insufficient arguments to $CC:

```
$ ./rebar compile
==> erlang-bcrypt (compile)
c_src/bcrypt_nif.c:22: fatal error: erl_nif.h: No such file or directory
compilation terminated.
ERROR: $CC c_src/blowfish.c c_src/bcrypt.c c_src/bcrypt_nif.c $LDFLAGS $DRV_LDFLAGS -o priv/bcrypt_nif.so failed with error: 1
```

I believe this patch fixes the problem by including `$CFLAGS` and `$DRV_CFLAGS` in the compilation command.
