### PR TITLE
I've added variable expansion in replace overlay

### DIFF
--- a/src/rebar_reltool.erl
+++ b/src/rebar_reltool.erl
@@ -341,7 +341,7 @@ execute_overlay([{replace, Out, Regex, Replacement, Opts} | Rest],
                 Vars, BaseDir, TargetDir) ->
     Filename = rebar_templater:render(filename:join(TargetDir, Out), Vars),
     {ok, OrigData} = file:read_file(Filename),
-    Data = re:replace(OrigData, Regex, Replacement,
+    Data = re:replace(OrigData, Regex, rebar_templater:render(Replacement, Vars),
                       [global, {return, binary}] ++ Opts),
     case file:write_file(Filename, Data) of
         ok ->


### PR DESCRIPTION
I want to do so:

```
       {copy, "contrib/rtmp_proxy", "bin/rtmp_proxy"},
       {replace, "bin/rtmp_proxy", "/usr/bin/env escript", "{{erts_vsn}}/bin/escript"},
```

and now I can got to /opt/erlyvideo and make there ./bin/rtmp_proxy
