### PR TITLE
problem is os envirenement in port_env

### DIFF
--- a/src/rebar_port_compiler.erl
+++ b/src/rebar_port_compiler.erl
@@ -153,7 +153,7 @@ setup_env(Config) ->
     DefaultEnvs  = filter_envs(default_env(), []),
     PortEnvs = rebar_config:get_list(Config, port_envs, []),
     OverrideEnvs = filter_envs(PortEnvs, []),
-    RawEnv = DefaultEnvs ++ OverrideEnvs ++ os_env(),
+    RawEnv = os_env() ++ DefaultEnvs ++ OverrideEnvs,
     expand_vars_loop(merge_each_var(RawEnv, [])).
 
 %% ===================================================================


### PR DESCRIPTION
if you set a port_env like this :

```
{port_envs, [

        {"(linux|freebsd)", "LDFLAGS", "$LDFLAGS -lstdc++ -lpthread"}
    ]}.
```

and do LDFLAGS="-lcurl" ./rebar compile, only -lcurl is set in LDFLAGS and port env config is ignored. This patch fix it.
