### PR TITLE
Set $REBAR_DEPS_DIR and $ERL_LIBS environment variables for rebar hooks

### DIFF
--- a/src/rebar_core.erl
+++ b/src/rebar_core.erl
@@ -317,25 +317,9 @@ apply_hook({Env, {Command, Hook}}) ->
     rebar_utils:sh(Hook, [{env, Env}, {abort_on_error, Msg}]).
 
 setup_envs(Config, Modules) ->
-    L = lists:flatten([M:setup_env(Config) ||
+    lists:flatten([M:setup_env(Config) ||
                       M <- Modules,
-                      erlang:function_exported(M, setup_env, 1)]),
-    make_extra_envs() ++ L.
-
-
-% make $REBAR_DEPS_DIR and $ERL_LIBS environment libraries
-make_extra_envs() ->
-    {true, DepsDir} = rebar_deps:get_deps_dir(),
-    [{"REBAR_DEPS_DIR", DepsDir},  make_erl_libs_var(DepsDir)].
-
-
-% make "ERL_LIBS" environent variable so that it includes rebar's DepsDir
-make_erl_libs_var(DepsDir) ->
-    case os:getenv("ERL_LIBS") of
-        false -> {"ERL_LIBS", DepsDir};
-        PrevValue -> {"ERL_LIBS", DepsDir ++ ":" ++ PrevValue}
-    end.
-
+                      erlang:function_exported(M, setup_env, 1)]).
 
 acc_modules(Modules, Command, Config, File) ->
     acc_modules(select_modules(Modules, Command, []),

--- a/src/rebar_deps.erl
+++ b/src/rebar_deps.erl
@@ -31,7 +31,7 @@
 -export([preprocess/2,
          postprocess/2,
          compile/2,
-         get_deps_dir/0,
+         setup_env/1,
          'check-deps'/2,
          'get-deps'/2,
          'update-deps'/2,
@@ -92,6 +92,17 @@ postprocess(_Config, _) ->
 
 compile(Config, AppFile) ->
     'check-deps'(Config, AppFile).
+
+% set REBAR_DEPS_DIR and ERL_LIBS environment libraries
+setup_env(_Config) ->
+    {true, DepsDir} = get_deps_dir(),
+    % include rebar's DepsDir in ERL_LIBS
+    ERL_LIBS =
+        case os:getenv("ERL_LIBS") of
+            false -> {"ERL_LIBS", DepsDir};
+            PrevValue -> {"ERL_LIBS", DepsDir ++ ":" ++ PrevValue}
+        end,
+    [{"REBAR_DEPS_DIR", DepsDir}, ERL_LIBS].
 
 'check-deps'(Config, _) ->
     %% Get the list of immediate (i.e. non-transitive) deps that are missing


### PR DESCRIPTION
Export two extra environment variables when executing shell commands.
These variables are useful for rebar hooks that rely on Erlang
applications installed as rebar dependencies.

$REBAR_DEPS_DIR contains a fully-qualified name of the directory where
rebar stores dependencies.

$ERL_LIBS is set to $REBAR_DEPS_DIR or to "$REBAR_DEPS_DIR:$ERL_LIBS",
if $ERL_LIBS was defined before.
