### PR TITLE
Set skip_deps for all destructive commands

### DIFF
--- a/src/rebar_core.erl
+++ b/src/rebar_core.erl
@@ -194,7 +194,8 @@ sanitize_unsafe_commands(Command) ->
             {Command, Skip};
         true ->
             case lists:member(CommandString,
-                              ["get-deps", "update-deps", "check-deps"]) of
+                              ["get-deps", "update-deps", 
+                               "check-deps", "delete-deps"]) of
                 true ->
                     {Command, Skip};
                 false ->


### PR DESCRIPTION
This patch alters rebar_core to set the global skip_deps
property prior to running any command that is not suffixed
by "-deps", resetting the prior (default) afterwards. This
prevents _all_ potentially destructive commands running in
deps directories unless explicitly requested. 

The user can explicitly clean/compile/generate/etc in deps
by suffixing the command appropriately, for example by 
running `rebar clean-deps compile-deps`.  
