### PR TITLE
Allow multiple sources in arch-specific port_sources

### DIFF
--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -35,8 +35,11 @@
 
 %% == Port Compiler ==
 
-%% List and wildcard list of files to be compiled. Default is `"c_src/*.c"'
-{port_sources, []}.
+%% List of filenames or wildcards to be compiled. May also contain a tuple
+%% consisting of a regular expression to be applied against the system
+%% architecture and a list of filenames or wildcards to include should the
+%% expression pass. Default is `"c_src/*.c"'
+{port_sources, ["c_src/*.c", {"R14", ["c_src/*.c"]}]}.
 
 %% Port compilation environment variables. See rebar_port_compiler.erl for
 %% more info. Default is `[]'

--- a/src/rebar_port_compiler.erl
+++ b/src/rebar_port_compiler.erl
@@ -38,11 +38,11 @@
 
 %% Supported configuration variables:
 %%
-%% * port_sources - Erlang list of files and/or wildcard strings to be
-%%                  compiled. Platform specific sources can be specified
-%%                  by enclosing a string in a tuple of the form
-%%                  {Regex, String} wherein Regex is a regular expression
-%%                  that is checked against the system architecture.
+%% * port_sources - Erlang list of filenames or wildcards to be compiled. May
+%%                  also contain a tuple consisting of a regular expression to
+%%                  be applied against the system architecture and a list of
+%%                  filenames or wildcards to include should the expression
+%%                  pass.
 %%
 %% * so_specs  - Erlang list of tuples of the form
 %%               {"priv/so_name.so", ["c_src/object_file_name.o"]}
@@ -165,7 +165,7 @@ expand_sources([], Acc) ->
 expand_sources([{ArchRegex, Spec} | Rest], Acc) ->
     case rebar_utils:is_arch(ArchRegex) of
         true ->
-            Acc2 = filelib:wildcard(Spec) ++ Acc,
+            Acc2 = expand_sources(Spec, Acc),
             expand_sources(Rest, Acc2);
         false ->
             expand_sources(Rest, Acc)


### PR DESCRIPTION
Allow a list of filenames/wildcards in addition to allowing a single filename/wildcard in architecture specific port_sources.
