### PR TITLE
Recursively search "src" for .proto files

### DIFF
--- a/src/rebar_protobuffs_compiler.erl
+++ b/src/rebar_protobuffs_compiler.erl
@@ -36,7 +36,7 @@
 %% ===================================================================
 
 compile(_Config, _AppFile) ->
-    case filelib:wildcard("src/*.proto") of
+    case rebar_utils:find_files("src", ".*\\.proto$") of
         [] ->
             ok;
         FoundFiles ->
@@ -60,7 +60,7 @@ compile(_Config, _AppFile) ->
 
 clean(_Config, _AppFile) ->
     %% Get a list of generated .beam and .hrl files and then delete them
-    Protos = filelib:wildcard("src/*.proto"),
+    Protos = rebar_utils:find_files("src", ".*\\.proto$"),
     BeamFiles = [fq_beam_file(F) || F <- Protos],
     HrlFiles = [fq_hrl_file(F) || F <- Protos],
     Targets = BeamFiles ++ HrlFiles,


### PR DESCRIPTION
This patch makes the protobuffs compiler perform a recursive search when looking for source files. The other compilers already perform similar recursive searches.

I recommend this patch over pull request 59 (https://github.com/basho/rebar/pull/59). That pull request searches the directories specified by the `src_dirs` option; however, `src_dirs` is not currently honored by the other compilers (only by EUnit) and therefore pull request 59 would create an inconsistency in rebar. (There are other technical problems with pull request 59 that I will list in a comment on its pull request page.)
