### PR TITLE
Fix rebar.bat path handling

### DIFF
--- a/rebar.bat
+++ b/rebar.bat
@@ -1,4 +1,4 @@
 @echo off
 setlocal
-set rebarscript=%0
-escript.exe %rebarscript:.bat=% %*
+set rebarscript=%~f0
+escript.exe "%rebarscript:.bat=%" %*


### PR DESCRIPTION
Use "%~f0" to get the full path of rebat.bat to correctly locate the
rebar script. Also put the script name in quotes when passing it to
escript.exe to correctly handle paths with spaces.
