### PR TITLE
Application environment variable `plugins`

### DIFF
--- a/src/rebar_core.erl
+++ b/src/rebar_core.erl
@@ -354,7 +354,14 @@ acc_modules([Module | Rest], Command, Config, File, Acc) ->
 %% Return a flat list of rebar plugin modules.
 %%
 plugin_modules(Config) ->
-    Modules = lists:flatten(rebar_config:get_all(Config, rebar_plugins)),
+    case application:get_env(rebar, plugins) of
+        {ok, GlobalPlugins} ->
+            ok;
+        _ ->
+            GlobalPlugins = []
+        end,
+    Plugins = GlobalPlugins ++ rebar_config:get_all(Config, rebar_plugins),
+    Modules = lists:flatten(Plugins),
     plugin_modules(Config, ulist(Modules)).
 
 ulist(L) ->


### PR DESCRIPTION
Allow specifying plugins through application environment variable `plugins`

It will allow applications that bundle rebar (such as agner) to specify their own plugins after or before the build phase so that their users won't need to add the plugin to their config files manually. Right now they have to add `{rebar_plugins, [agner_rebar_plugin]}` to each and every project that uses agner, which is not very convenient at all. The way agner works is that it bundles stock rebar with its own modules so that users can use rebar plugin. Avoiding the need to specify agner plugin manually will be another barrier removal.
