### PR TITLE
Backport changes to riak's runner script to propagate return values

### DIFF
--- a/priv/templates/simplenode.runner
+++ b/priv/templates/simplenode.runner
@@ -73,7 +73,7 @@ case "$1" in
         # the user know when riak is crashing right after startup.
         WAIT=${WAIT_FOR_ERLANG:-15}
         while [ $WAIT -gt 0 ]; do
-            WAIT=$[$WAIT - 1]
+            WAIT=`expr $WAIT - 1`
             sleep 1
             RES=`$NODETOOL ping`
             if [ "$?" -ne 0 ]; then


### PR DESCRIPTION
This makes the runner's exit status codes meaningful and also makes the script block during the 'start' phase.
