### PR TITLE
support for {dir, src, dst} as cp -r

### DIFF
--- a/src/rebar_templater.erl
+++ b/src/rebar_templater.erl
@@ -359,7 +359,7 @@ execute_template([{dir, Name} | Rest], TemplateType, TemplateName, Context,
             ?ABORT("Failed while processing template instruction "
                    "{dir, ~s}: ~p\n", [Name, Reason])
     end;
-execute_template([{dir, Input, Output} | Rest], TemplateType, TemplateName,
+execute_template([{copy, Input, Output} | Rest], TemplateType, TemplateName,
                  Context, Force, ExistingFiles) ->
     InputName = filename:join(filename:dirname(TemplateName), Input),
     case rebar_file_utils:cp_r([InputName ++ "/*"], Output) of


### PR DESCRIPTION
I needed a general-purpose way to copy directory structures in rebar templates. It didn't seem like this was available, so I added it as a special case of the `dir` command.

I'm using it to copy some dependencies over on `rebar create`, with a custom template.

It would be great if this, or something similar was available in rebar.

Cheers!
