### PR TITLE
Restore R13B03 compatibility

### DIFF
--- a/include/rebar.hrl
+++ b/include/rebar.hrl
@@ -13,6 +13,3 @@
 
 -define(DEPRECATED(Key, Old, New, Opts, When),
         rebar_utils:deprecated(Key, Old, New, Opts, When)).
-
--define(DEPRECATED(Key, Old, New, When),
-        rebar_utils:deprecated(Key, Old, New, When)).


### PR DESCRIPTION
The ability to overload macros was added in Erlang R13B04.
The second form was not used anyway.
