### PR TITLE
Respect the --config switch when given

### DIFF
--- a/inttest/t_custom_config/custom.config
+++ b/inttest/t_custom_config/custom.config
@@ -1,0 +1,2 @@
+
+{erl_opts, [warnings_as_errors]}.

--- a/inttest/t_custom_config/custom_config.erl
+++ b/inttest/t_custom_config/custom_config.erl
@@ -1,0 +1,5 @@
+-module(custom_config).
+
+-compile(export_all).
+
+test() -> it.

--- a/inttest/t_custom_config/t_custom_config_rt.erl
+++ b/inttest/t_custom_config/t_custom_config_rt.erl
@@ -1,0 +1,31 @@
+-module(t_custom_config_rt).
+
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+
+files() ->
+    [{copy, "custom.config", "custom.config"},
+     {create, "ebin/custom_config.app", app(custom_config, [custom_config])}].
+
+run(Dir) ->
+    retest_log:log(debug, "Running in Dir: ~s~n", [Dir]),
+    Ref = retest:sh("rebar -C custom.config check-deps -v", [{async, true}]),
+    {ok, Captured} = retest:sh_expect(Ref,
+                    "DEBUG: Consult config file .*/custom.config.*",
+                    [{capture, all, list}]),
+    retest_log:log(debug, "[CAPTURED]: ~s~n", [Captured]),
+    ok.
+
+%%
+%% Generate the contents of a simple .app file
+%%
+app(Name, Modules) ->
+    App = {application, Name,
+           [{description, atom_to_list(Name)},
+            {vsn, "1"},
+            {modules, Modules},
+            {registered, []},
+            {applications, [kernel, stdlib]}]},
+    io_lib:format("~p.\n", [App]).
+

--- a/src/rebar.erl
+++ b/src/rebar.erl
@@ -108,9 +108,10 @@ run_aux(Commands) ->
                        false ->
                            rebar_config:new()
                    end,
+    BaseConfig = rebar_config:base_config(GlobalConfig),
 
     %% Process each command, resetting any state between each one
-    rebar_core:process_commands(CommandAtoms, GlobalConfig).
+    rebar_core:process_commands(CommandAtoms, BaseConfig).
 
 %%
 %% print help/usage string


### PR DESCRIPTION
Currently the --config switch does not work because when loading
a new rebar config the global setting is ignored for all paths.
This patch provides a check when loading new rebar config to see
whether or not the current config path matches the `base_dir` set in
global conf, which produces the expected behaviour.
