### PR TITLE
Remove escript from code path before running eunit.

### DIFF
--- a/src/rebar_eunit.erl
+++ b/src/rebar_eunit.erl
@@ -167,6 +167,12 @@ perform_eunit(Config, Modules) ->
     Cwd = rebar_utils:get_cwd(),
     ok = file:set_cwd(?EUNIT_DIR),
 
+    %% Remove the rebar escript from the code path so that module lookup
+    %% during the test run doesn't result in spurious bad_central_directory
+    %% error reports from Erlang's zip loader.  The code path will be restored
+    %% as the last step of the eunit command.
+    code:del_path(rebar_config:get_global(escript, undefined)),
+
     EunitResult = perform_eunit(EunitOpts, Modules, Suite),
 
     %% Return to original working dir


### PR DESCRIPTION
It appears that when the erlang loader finds the rebar escript on the code
path, which does _not_ have the module it is attempting to load it results in
the following error message being logged.

=ERROR REPORT==== 3-Aug-2011::09:21:21 ===
File operation error: bad_central_directory. Target:
/path/to/rebar/calendar.beam. Function: get_file. Process: code_server.

For a sizeable project with a comprehensive test suite this can introduce
quite a lot of noise into the rebar eunit output.

We can work around this problem by removing the rebar escript from the code
path just before we run the eunit tests.
