### PR TITLE
Correction to simplenode.runner template

### DIFF
--- a/priv/templates/simplenode.runner
+++ b/priv/templates/simplenode.runner
@@ -30,7 +30,7 @@ if [ -z "$NAME_ARG" ]; then
 fi
 
 # Extract the target cookie
-COOKIE_ARG=`grep '^-setcookie' $RUNNER_ETC_DIR/vm.args`
+COOKIE_ARG=`egrep '^-setcookie' $RUNNER_ETC_DIR/vm.args`
 if [ -z "$COOKIE_ARG" ]; then
     echo "vm.args needs to have a -setcookie parameter."
     exit 1


### PR DESCRIPTION
When using rebar under Solaris, the native grep does not support the -e option for searching regular expressions. The first grep -e for node name (-[s]*name) was already changed, but the grep -e for set cookie had not been, so I've corrected it.
