### PR TITLE
Fix eunit with surefire reports

### DIFF
--- a/src/rebar_eunit.erl
+++ b/src/rebar_eunit.erl
@@ -175,7 +175,11 @@ perform_eunit(Config, Modules) ->
     EunitResult.
 
 perform_eunit(EunitOpts, Modules, undefined) ->
-    (catch eunit:test(Modules, EunitOpts));
+    Res = [(catch eunit:test(Module, EunitOpts))||Module<-Modules],
+    case [R||R<-Res, R/=ok] of
+        [] -> ok;
+        X -> {error,X}
+    end;
 perform_eunit(EunitOpts, _Modules, Suites) ->
     (catch eunit:test([list_to_atom(Suite) ||
                           Suite <- string:tokens(Suites, ",")], EunitOpts)).


### PR DESCRIPTION
This is a workaround for a probable eunit bug.
When rebar eunit is run with
 {eunit_opts, [{report, {eunit_surefire, [{dir,"."}]}}]}
All the results are placed in .eunit/TEST-<last_module>.xml
Instead of generating one TEST-<my_mod_name>.xml for each module.
