### PR TITLE
Add precise versioning of multiple apps per repo when git vsn is used.

### DIFF
--- a/src/rebar_app_utils.erl
+++ b/src/rebar_app_utils.erl
@@ -163,7 +163,7 @@ vcs_vsn(Vcs, Dir) ->
             end
     end.
 
-vcs_vsn_cmd(git) -> "git describe --always --tags";
+vcs_vsn_cmd(git) -> "git describe --always --tags `git log -n 1 --pretty=format:%h .`";
 vcs_vsn_cmd(hg)  -> "hg identify -i";
 vcs_vsn_cmd(bzr) -> "bzr revno";
 vcs_vsn_cmd(svn) -> "svnversion";


### PR DESCRIPTION
Allows using tools like git-subtree and still maintaining proper
git-based vsns for those "imported" subtrees. Also helps understanding
what was the last change introduced to a specific application within a
multi-application repository (at this moment, all applications that
reside in the same repository, will share the same autogenerated git
vsn)
