### PR TITLE
specify the erlang system module name while calling monitor/2

### DIFF
--- a/src/rebar_eunit.erl
+++ b/src/rebar_eunit.erl
@@ -562,7 +562,7 @@ reconstruct_app_env_vars([]) ->
     ok.
 
 wait_until_dead(Pid) when is_pid(Pid) ->
-    Ref = monitor(process, Pid),
+    Ref = erlang:monitor(process, Pid),
     receive
         {'DOWN', Ref, process, _Obj, Info} ->
             Info


### PR DESCRIPTION
Hi, 

thanks for rebar!

Today, the master branch fails to compile on Erlang R13B03:
    Recompile: src/rebar_eunit
    src/rebar_eunit.erl:565: function monitor/2 undefined

The call to monitor/2 was introduced by merging with slf-eunit-process-isolation2 branch, 3 days ago: https://github.com/basho/rebar/commit/9832a5c5c637804a6420869d58a278e28cd51f09#src/rebar_eunit.erl

The proposed update restores the ability to compile on R13B03 by simply specifying the erlang system module name while calling monitor/2.

Cheers,
alfonso
