### PR TITLE
Check if include directory exists before moving .hrl files

### DIFF
--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -270,6 +270,7 @@ internal_erl_compile(Source, Config, Outdir, ErlOpts) ->
                   Config::rebar_config:config()) -> 'ok'.
 compile_mib(Source, Target, Config) ->
     ok = rebar_utils:ensure_dir(Target),
+    ok = rebar_utils:ensure_dir("include/"), % the '/' indicates a directory
     Opts = [{outdir, "priv/mibs"}, {i, ["priv/mibs"]}] ++
         rebar_config:get(Config, mib_opts, []),
     case snmpc:compile(Source, Opts) of
@@ -277,7 +278,7 @@ compile_mib(Source, Target, Config) ->
             Mib = filename:rootname(Target),
             ok = snmpc:mib_to_hrl(Mib),
             Hrl_filename = Mib ++ ".hrl",
-            rebar_file_utils:mv(Hrl_filename,"include"),
+            rebar_file_utils:mv(Hrl_filename, "include"),
             ok;
         {error, compilation_failed} ->
             ?FAIL


### PR DESCRIPTION
When compiling MIB files rebar_erlc_compiler does not check whether an include directory exists and thus when writing MIB header files all of the 'mv' commands simple overwrite Target/include as a file.
