### PR TITLE
Remove modules that fail coverage from the list.

### DIFF
--- a/src/rebar_eunit.erl
+++ b/src/rebar_eunit.erl
@@ -281,7 +281,7 @@ cover_analyze(Config, Modules, SrcModules) ->
                       end,
 
     %% Generate coverage info for all the cover-compiled modules
-    Coverage = [cover_analyze_mod(M) || M <- FilteredModules],
+    Coverage = lists:flatten([cover_analyze_mod(M) || M <- FilteredModules]),
 
     %% Write index of coverage info
     cover_write_index(lists:sort(Coverage), SrcModules),
@@ -364,12 +364,12 @@ cover_analyze_mod(Module) ->
             %% test/0 fun, which cover considers a runnable line, but
             %% eunit:test(TestRepresentation) never calls.  Decrement
             %% NotCovered in this case.
-            align_notcovered_count(Module, Covered, NotCovered,
-                                   is_eunitized(Module));
+            [align_notcovered_count(Module, Covered, NotCovered,
+                                    is_eunitized(Module))];
         {error, Reason} ->
             ?ERROR("Cover analyze failed for ~p: ~p ~p\n",
                    [Module, Reason, code:which(Module)]),
-            {0,0}
+            []
     end.
 
 is_eunitized(Mod) ->


### PR DESCRIPTION
I had problems with cover failing to analyze a module after eunit ran.  The current code is adding {0,0} when it fails which doesn't match what cover generates {Mod, 0, 0}.  Instead I just remove the module from the list.
