### PR TITLE
Fix --config handling again

### DIFF
--- a/inttest/t_custom_config/custom.config
+++ b/inttest/t_custom_config/custom.config
@@ -1,1 +1,5 @@
+
+{deps, [
+    {boo, "."}
+]}.
 {erl_opts, [warnings_as_errors]}.

--- a/inttest/t_custom_config/t_custom_config_rt.erl
+++ b/inttest/t_custom_config/t_custom_config_rt.erl
@@ -5,17 +5,24 @@
 -include_lib("eunit/include/eunit.hrl").
 
 files() ->
-    [{copy, "custom.config", "custom.config"},
+    [{copy, "../../rebar", "rebar"},
+     {copy, "custom.config", "custom.config"},
      {create, "ebin/custom_config.app", app(custom_config, [custom_config])}].
 
 run(Dir) ->
     retest_log:log(debug, "Running in Dir: ~s~n", [Dir]),
-    Ref = retest:sh("rebar -C custom.config check-deps -v", [{async, true}]),
+    Ref = retest:sh("./rebar -C custom.config check-deps -v", [{async, true}]),
     {ok, Captured} =
         retest:sh_expect(Ref,
                          "DEBUG: Consult config file .*/custom.config.*",
                          [{capture, all, list}]),
+    {ok, Missing} =
+        retest:sh_expect(Ref,
+                     "DEBUG: Missing deps  : \\[\\{dep,bad_name,"
+                     "boo,\"\\.\",undefined\\}\\]",
+                     [{capture, all, list}]),
     retest_log:log(debug, "[CAPTURED]: ~s~n", [Captured]),
+    retest_log:log(debug, "[Missing]: ~s~n", [Missing]),
     ok.
 
 %%

--- a/src/rebar_core.erl
+++ b/src/rebar_core.erl
@@ -102,7 +102,7 @@ process_dir(Dir, ParentConfig, Command, DirSet) ->
         true ->
             ?DEBUG("Entering ~s\n", [Dir]),
             ok = file:set_cwd(Dir),
-            Config = rebar_config:new(ParentConfig),
+            Config = maybe_load_local_config(Dir, ParentConfig),
 
             %% Save the current code path and then update it with
             %% lib_dirs. Children inherit parents code path, but we
@@ -184,7 +184,18 @@ process_dir(Dir, ParentConfig, Command, DirSet) ->
             DirSet4
     end.
 
+maybe_load_local_config(Dir, ParentConfig) ->
+    %% We need to ensure we don't overwrite custom 
+    %% config when we are dealing with base_dir.
+    case processing_base_dir(Dir) of
+        true ->
+            ParentConfig;
+        false ->
+            rebar_config:new(ParentConfig)
+    end.
 
+processing_base_dir(Dir) ->
+    Dir == rebar_config:get_global(base_dir, undefined).
 
 %%
 %% Given a list of directories and a set of previously processed directories,


### PR DESCRIPTION
Avoid overwriting custom config (passed with -C) when we are processing the base_dir in rebar_core.
