### PR TITLE
--config switch fix

### DIFF
--- a/src/rebar_config.erl
+++ b/src/rebar_config.erl
@@ -65,7 +65,13 @@ new(ConfigFile) when is_list(ConfigFile) ->
             ?ABORT("Failed to load ~s: ~p~n", [ConfigFile, Other])
     end;
 new(_ParentConfig=#config{opts=Opts0})->
-    new(Opts0, "rebar.config").
+    BaseDir = rebar_config:get_global(base_dir, undefined),
+    case rebar_utils:get_cwd() of
+        BaseDir ->
+            new(Opts0, rebar_config:get_global(config, "rebar.config"));
+        _ ->
+            new(Opts0, "rebar.config")
+    end.
 
 new(Opts0, ConfName) ->
     %% Load terms from rebar.config, if it exists


### PR DESCRIPTION
When --config switch is supplied, if it is a base directory, specified config should be used.

Before this patch, it works this way:

```
./rebar -v -C test.config compile
DEBUG: Rebar location: "/Users/yrashk/tmp/rebar/rebar"
DEBUG: Consult config file "/Users/yrashk/tmp/rebar/test.config"
DEBUG: Entering /Users/yrashk/tmp/rebar
DEBUG: Consult config file "/Users/yrashk/tmp/rebar/rebar.config"
```

After this patch, it works this way:

```
./rebar -v -C test.config compile
DEBUG: Rebar location: "/Users/yrashk/tmp/rebar/rebar"
DEBUG: Consult config file "/Users/yrashk/tmp/rebar/test.config"
DEBUG: Entering /Users/yrashk/tmp/rebar
DEBUG: Consult config file "/Users/yrashk/tmp/rebar/test.config"
```
