### PR TITLE
Make source directories unique list

### DIFF
--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -330,7 +330,7 @@ gather_src([Dir|Rest], Srcs) ->
 src_dirs([]) ->
     ["src"];
 src_dirs(SrcDirs) ->
-    SrcDirs ++ src_dirs([]).
+    lists:usort(SrcDirs ++ src_dirs([])).
 
 -spec dirs(Dir::file:filename()) -> [file:filename()].
 dirs(Dir) ->


### PR DESCRIPTION
When traversing dependency tree, every dependency gets its "src"
directory appended to SrcDirs.

Rebar compiles files in parallel, and a race condition occurs when two
processes start compilig the same file.

Minimal testcase. Consider this tree (audit, cbeam and ejson2 are
rebar-generated apps). Audit depends on cbeam, cbeam depends on ejson2.

.
├── audit
│   ├── ebin
│   ├── rebar.config
│   └── src
│       ├── audit_app.erl
│       ├── audit.app.src
│       └── audit_sup.erl
├── deps
│   ├── cbeam
│   │   ├── ebin
│   │   ├── rebar.config
│   │   └── src
│   │       ├── cbeam_app.erl
│   │       ├── cbeam.app.src
│   │       └── cbeam_sup.erl
│   └── ejson2
│       ├── ebin
│       └── src
│           ├── ejson2_app.erl
│           ├── ejson2.app.src
│           └── ejson2_sup.erl
└── rebar

audit/$ ../rebar compile
==> ejson2 (compile)
Compiled src/ejson2_app.erl
Compiled src/ejson2_app.erl
Compiled src/ejson2_sup.erl
==> cbeam (compile)
Compiled src/cbeam_app.erl
Compiled src/cbeam_app.erl
Compiled src/cbeam_sup.erl
Compiled src/cbeam_sup.erl
==> audit (compile)
Compiled src/audit_app.erl
Compiled src/audit_sup.erl
ebin/audit_sup.beam: failed to delete temporary file
ebin/audit_sup.bea#: no such file or directory
ebin/audit_sup.beam: failed to rename ebin/audit_sup.bea# to
ebin/audit_sup.beam: no such file or directory

Solve this by forcing SrcDirs to be a set.
