### PR TITLE
Make source directories a unique list

### DIFF
--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -140,7 +140,7 @@ doterl_compile(Config, OutDir, MoreSources) ->
     %% Support the src_dirs option allowing multiple directories to
     %% contain erlang source. This might be used, for example, should
     %% eunit tests be separated from the core application source.
-    SrcDirs = src_dirs(proplists:append_values(src_dirs, ErlOpts)),
+    SrcDirs = lists:usort(src_dirs(proplists:append_values(src_dirs, ErlOpts))),
     RestErls  = [Source || Source <- gather_src(SrcDirs, []) ++ MoreSources,
                            not lists:member(Source, FirstErls)],
 


### PR DESCRIPTION
If I append "src" to list of src_dirs, source files are added to to
compile list twice. It might happen that rebar tries to compile both
files at once, and compilation fails.

Steps to reproduce:

$ ./rebar create-app appid=yammy
==> yammy (create-app)
dWriting src/yammy.app.src
Writing src/yammy_app.erl
Writing src/yammy_sup.erl
$ echo '{erl_opts, [{src_dirs, ["src"]}]}.' > rebar.config
$ ./rebar compile (run ./rebar clean compile several times to reproduce)
==> yammy (compile)
Compiled src/yammy_app.erl
Compiled src/yammy_sup.erl
ebin/yammy_app.beam: failed to delete temporary file
ebin/yammy_app.bea#: no such file or directory
ebin/yammy_app.beam: failed to rename ebin/yammy_app.bea# to
ebin/yammy_app.beam: no such file or directory

This patch ensures that source directories are unique.
