### PR TITLE
Add support to port compiler for observing first_files

### DIFF
--- a/src/rebar_port_compiler.erl
+++ b/src/rebar_port_compiler.erl
@@ -96,18 +96,37 @@
 %%
 
 compile(Config, AppFile) ->
+    %% Allow the user to specify that dependent files get built first
+    FirstFiles = expand_sources(rebar_config:get(Config, 
+                                                 port_first_files, []), []),
+
     %% Compose list of sources from config file -- defaults to c_src/*.c
     Sources = expand_sources(rebar_config:get_list(Config, port_sources,
                                                    ["c_src/*.c"]), []),
+    Env = setup_env(Config),
+
+    {FirstNewBins, FirstExistingBins} = case FirstFiles of
+                                            [] ->
+                                                {[], []};
+                                            _ ->
+                                            compile_each(FirstFiles, Config,
+                                                         Env, [], [])
+                                        end,
     case Sources of
         [] ->
             ok;
         _ ->
-            Env = setup_env(Config),
+
+            %% Remove first files from found files
+            RestFiles = [Source || Source <- Sources,
+                                   not lists:member(Source, FirstFiles)],
 
             %% Compile each of the sources
-            {NewBins, ExistingBins} = compile_each(Sources, Config, Env,
-                                                   [], []),
+            {NewBins, ExistingBins} = compile_each(RestFiles, Config, Env,
+                                                     [], []),
+
+            NewBins = FirstNewBins ++ NewBins,
+            ExistingBins = FirstExistingBins ++ ExistingBins,
 
             %% Construct the driver name and make sure priv/ exists
             SoSpecs = so_specs(Config, AppFile, NewBins ++ ExistingBins),


### PR DESCRIPTION
This patch adds support for first_files in the port_compiler, via the new `port_first_files` rebar config element.
