### PR TITLE
Allow plugins to participate in pre and post processing

### DIFF
--- a/src/rebar_core.erl
+++ b/src/rebar_core.erl
@@ -128,8 +128,18 @@ process_dir(Dir, ParentConfig, Command, DirSet) ->
             %% Invoke 'preprocess' on the modules -- this yields a list of other
             %% directories that should be processed _before_ the current one.
             Predirs = acc_modules(Modules, preprocess, Config, ModuleSetFile),
-            ?DEBUG("Predirs: ~p\n", [Predirs]),
-            DirSet2 = process_each(Predirs, Command, Config,
+
+            %% Get the list of plug-in modules from rebar.config. These
+            %% modules may participate in preprocess and postprocess.
+            {ok, PluginModules} = plugin_modules(Config),
+
+            PluginPredirs = acc_modules(PluginModules, preprocess, 
+                                        Config, ModuleSetFile),
+
+            AllPredirs = Predirs ++ PluginPredirs,
+
+            ?DEBUG("Predirs: ~p\n", [AllPredirs]),
+            DirSet2 = process_each(AllPredirs, Command, Config,
                                    ModuleSetFile, DirSet),
 
             %% Make sure the CWD is reset properly; processing the dirs may have
@@ -144,11 +154,6 @@ process_dir(Dir, ParentConfig, Command, DirSet) ->
                     ?INFO("Skipping ~s in ~s\n", [Command, Dir]);
 
                 false ->
-                    %% Get the list of plug-in modules from rebar.config. These
-                    %% modules are processed LAST and do not participate
-                    %% in preprocess.
-                    {ok, PluginModules} = plugin_modules(Config),
-
                     %% Execute any before_command plugins on this directory
                     execute_pre(Command, PluginModules,
                                 Config, ModuleSetFile),
@@ -167,7 +172,8 @@ process_dir(Dir, ParentConfig, Command, DirSet) ->
 
             %% Invoke 'postprocess' on the modules. This yields a list of other
             %% directories that should be processed _after_ the current one.
-            Postdirs = acc_modules(Modules, postprocess, Config, ModuleSetFile),
+            Postdirs = acc_modules(Modules ++ PluginModules, postprocess,
+                                   Config, ModuleSetFile),
             ?DEBUG("Postdirs: ~p\n", [Postdirs]),
             DirSet4 = process_each(Postdirs, Command, Config,
                                    ModuleSetFile, DirSet3),

--- a/src/rebar_deps.erl
+++ b/src/rebar_deps.erl
@@ -201,6 +201,7 @@ update_deps_code_path([Dep | Rest]) ->
         {true, _} ->
             Dir = filename:join(Dep#dep.dir, "ebin"),
             ok = filelib:ensure_dir(filename:join(Dir, "dummy")),
+            ?DEBUG("Adding ~s to code path", [Dir]),
             true = code:add_patha(Dir);
         {false, _} ->
             true


### PR DESCRIPTION
This patch modifies rebar_core to allow plugins to participate in the
pre and post processing steps, giving plugin authors more flexibility
and control.
