### PR TITLE
Add support for customising common test directory

### DIFF
--- a/inttest/ct1/ct1_rt.erl
+++ b/inttest/ct1/ct1_rt.erl
@@ -6,7 +6,8 @@
 files() ->
     [{create, "ebin/a1.app", app(a1)},
      {copy, "../../rebar", "rebar"},
-     {copy, "test_SUITE.erl", "test/test_SUITE.erl"}].
+     {copy, "rebar.config", "rebar.config"},
+     {copy, "test_SUITE.erl", "itest/test_SUITE.erl"}].
 
 run(_Dir) ->
     {ok, _} = retest:sh("./rebar compile ct"),

--- a/inttest/ct1/rebar.config
+++ b/inttest/ct1/rebar.config
@@ -1,0 +1,2 @@
+
+{ct_dir, "itest"}.

--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -83,6 +83,9 @@
 
 %% == Common Test ==
 
+%% Override the default "test" directory in which SUITEs are located
+{ct_dir, "itest"}.
+
 %% Option to pass extra parameters when launching Common Test
 {ct_extra_params, "-boot start_sasl -s myapp"}.
 

--- a/src/rebar_ct.erl
+++ b/src/rebar_ct.erl
@@ -46,16 +46,17 @@
 %% ===================================================================
 
 ct(Config, File) ->
+	TestDir = rebar_config:get_local(Config, ct_dir, "test"),
     case rebar_config:get_global(app, undefined) of
         undefined ->
             %% No app parameter specified, run everything..
-            run_test_if_present("test", Config, File);
+            run_test_if_present(TestDir, Config, File);
         Apps ->
             TargetApps = [list_to_atom(A) || A <- string:tokens(Apps, ",")],
             ThisApp = rebar_app_utils:app_name(File),
             case lists:member(ThisApp, TargetApps) of
                 true ->
-                    run_test_if_present("test", Config, File);
+                    run_test_if_present(TestDir, Config, File);
                 false ->
                     ?DEBUG("Skipping common_test on app: ~p\n", [ThisApp])
             end


### PR DESCRIPTION
This patch allows users to specify the directory in which common_test
source files can be found. Most common_test suites are integration,
rather than unit tests and keeping the sources apart from test sources
for other frameworks such as eunit and PropEr is a useful feature.
