### PR TITLE
Fix missing plugin warnings

### DIFF
--- a/src/rebar_core.erl
+++ b/src/rebar_core.erl
@@ -392,7 +392,7 @@ plugin_modules(Config, FoundModules, MissingModules) ->
     case NotLoaded =/= [] of
         true ->
             %% NB: we continue to ignore this situation, as did the original code
-            ?WARN("Missing plugins: ~p\n", NotLoaded);
+            ?WARN("Missing plugins: ~p\n", [NotLoaded]);
         false ->
             ?DEBUG("Loaded plugins: ~p~n", [AllViablePlugins]),
             ok


### PR DESCRIPTION
This patch fixes the warning logging when the number of missing plugins
is greater than one. The current code only works by accident, when a
single plugin is all that is missing.
