### PR TITLE
Collect callbacks from multiple/all behaviours

### DIFF
--- a/src/rebar_xref.erl
+++ b/src/rebar_xref.erl
@@ -143,12 +143,7 @@ filter_away_ignored(UnusedExports) ->
 
 
 kf(Key, List) ->
-    case lists:keyfind(Key, 1, List) of
-        {Key, Value} ->
-            Value;
-        false ->
-            []
-    end.
+    lists:flatten(proplists:get_all_values(Key, List)).
 
 display_mfas([], _Message) ->
     ok;


### PR DESCRIPTION
Multiple behaviours are not collected as [{behaviour, [beh1, beh2]}] but 
[{behaviour, [beh1]}, {behaviour, [beh2]}]. I suppose this is an inconsistency
in the preprocessor when parsing module directives.
