### PR TITLE
handle functions missing from source in find_mfa_source/1

### DIFF
--- a/src/rebar_xref.erl
+++ b/src/rebar_xref.erl
@@ -188,8 +188,14 @@ find_mfa_source({M, F, A}) ->
     %% Extract the original source filename from the abstract code
     [{attribute, 1, file, {Source, _}} | _] = Code,
     %% Extract the line number for a given function def
-    [{function, Line, F, _, _}] = [E || E <- Code,
-                                        safe_element(1, E) == function,
-                                        safe_element(3, E) == F,
-                                        safe_element(4, E) == A],
-    {Source, Line}.
+    Fn = [E || E <- Code,
+               safe_element(1, E) == function,
+               safe_element(3, E) == F,
+               safe_element(4, E) == A],
+    case Fn of
+        [{function, Line, F, _, _}] -> {Source, Line};
+        %% do not crash if functions are exported, even though they
+        %% are not in the source.
+        %% parameterized modules add new/1 and instance/1 for example.
+        [] -> {Source, function_not_found}
+    end.


### PR DESCRIPTION
Hi,

Currently "rebar xref" crashes when trying to find the location of a
function definition in the source code for a function that does not
have one.

ERROR: xref failed while processing <snipped>: {'EXIT',{{badmatch,[]},
         [{rebar_xref,find_mfa_source,1},
          {rebar_xref,display_mfas,2},
          {rebar_xref,check_exports_not_used,0},
          {rebar_xref,xref,2},
          {rebar_core,run_modules,4},
          {rebar_core,execute,4},
          {rebar_core,process_dir,4},
          {rebar_core,process_commands,2}]}}

This can happen for example with parameterized modules, the beam code
will have a compiler generated new/1 and instance/1 function, that is
not in the original source code.

If while checking the beam, xref detects one of those is unused, the
rebars xref wrapper will try to find the location of the definition of
that function in the source code for the module (to give a more
specific warning to the user). Since the function was generated by the
compiler it does not actually exist in the source, and rebar crashes
at that stage. This patch works around that issue.

best regards,
   Fabian
