### PR TITLE
Publish issued, current and remaining commands in config

### DIFF
--- a/src/rebar.erl
+++ b/src/rebar.erl
@@ -110,6 +110,9 @@ run_aux(Commands) ->
                    end,
     BaseConfig = rebar_config:base_config(GlobalConfig),
 
+    %% Publish the originally given commands
+    rebar_config:set_global(issued_commands, CommandAtoms),
+
     %% Process each command, resetting any state between each one
     rebar_core:process_commands(CommandAtoms, BaseConfig).
 

--- a/src/rebar_core.erl
+++ b/src/rebar_core.erl
@@ -76,6 +76,10 @@ process_commands([Command | Rest], ParentConfig) ->
     lists:foreach(fun (D) -> erlang:erase({skip_dir, D}) end, skip_dirs()),
     Operations = erlang:get(operations),
 
+    %% Publish the current command and remaining pipeline in our config
+    rebar_config:set_global(current_command, Command),
+    rebar_config:set_global(remaining_commands, Rest),
+
     %% Convert the code path so that all the entries are absolute paths.
     %% If not, code:set_path() may choke on invalid relative paths when trying
     %% to restore the code path from inside a subdirectory.
@@ -90,6 +94,8 @@ process_commands([Command | Rest], ParentConfig) ->
         _ ->
             ok
     end,
+    PreviousCommands = rebar_config:get_global(previous_commands, []),
+    rebar_config:set_global(previous_commands, [Command|PreviousCommands]),
     process_commands(Rest, ParentConfig).
 
 

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -26,7 +26,8 @@
 %% -------------------------------------------------------------------
 -module(rebar_utils).
 
--export([get_cwd/0,
+-export([command_info/1,
+         get_cwd/0,
          is_arch/1,
          get_arch/0,
          wordsize/0,
@@ -50,6 +51,17 @@
 %% ====================================================================
 %% Public API
 %% ====================================================================
+
+command_info(current) ->
+    rebar_config:get_global(current_command, undefined);
+command_info(remaining) ->
+    rebar_config:get_global(remaining_commands, undefined);
+command_info(previous) ->
+    rebar_config:get_global(previous_commands, undefined);
+command_info(issued) ->
+    rebar_config:get_global(issued_commands, undefined);
+command_info(_) ->
+    undefined.
 
 get_cwd() ->
     {ok, Dir} = file:get_cwd(),


### PR DESCRIPTION
This patch adds the original, current and remaining commands to global config.
This information is useful to plugin authors who wish to know how rebar was
originally invoked, and how far along the build pipeline has progressed.
