### PR TITLE
Support for custom version commands

### DIFF
--- a/src/rebar_app_utils.erl
+++ b/src/rebar_app_utils.erl
@@ -139,6 +139,8 @@ vcs_vsn(Vcs, Dir) ->
         {unknown, VsnString} ->
             ?DEBUG("vcs_vsn: Unknown VCS atom in vsn field: ~p\n", [Vcs]),
             VsnString;
+        {cmd, CmdString} ->
+            vcs_vsn_invoke(CmdString, Dir);
         Cmd ->
             %% If there is a valid VCS directory in the application directory,
             %% use that version info
@@ -173,6 +175,7 @@ vcs_vsn_cmd(git) ->
 vcs_vsn_cmd(hg)  -> "hg identify -i";
 vcs_vsn_cmd(bzr) -> "bzr revno";
 vcs_vsn_cmd(svn) -> "svnversion";
+vcs_vsn_cmd({cmd, Cmd}=Custom) -> Custom;
 vcs_vsn_cmd(Version) -> {unknown, Version}.
 
 vcs_vsn_invoke(Cmd, Dir) ->


### PR DESCRIPTION
This patch adds support for customising the way in which rebar generates
version numbers for app.src files using the `{vsn,Spec}` approach.
Whilst the existing `{vsn,ScmName::atom()}` syntax will continue to
work, users can also pass `{vsn,{cmd,Cmd::string()}}` in which
case the provided _scm command_ will be used. For example:

``` erlang
{application, doodah,
 [
  {vsn, {cmd, "git rev-parse --short HEAD"}}]}.
```
