### PR TITLE
Add root_dir option to reltool.config

### DIFF
--- a/src/rebar_rel_utils.erl
+++ b/src/rebar_rel_utils.erl
@@ -38,6 +38,7 @@
          load_config/1,
          get_sys_tuple/1,
          get_target_dir/1,
+         get_root_dir/1,
          get_target_parent_dir/1]).
 
 -include("rebar.hrl").
@@ -156,6 +157,23 @@ get_target_dir(ReltoolConfig) ->
             end;
         TargetDir ->
             filename:absname(TargetDir)
+    end.
+
+%%
+%% Look for {root_dir, RootDir} in the reltool config file; if none is
+%% found, use the name of the release as the default target directory.
+%%
+get_root_dir(ReltoolConfig) ->
+    case rebar_config:get_global(root_dir, undefined) of
+        undefined ->
+            case lists:keyfind(root_dir, 1, ReltoolConfig) of
+                {root_dir, RootDir} ->
+                    filename:absname(RootDir);
+                false ->
+                    code:root_dir()
+            end;
+        RootDir ->
+            filename:absname(RootDir)
     end.
 
 get_target_parent_dir(ReltoolConfig) ->

--- a/src/rebar_reltool.erl
+++ b/src/rebar_reltool.erl
@@ -161,11 +161,14 @@ run_reltool(Server, _Config, ReltoolConfig) ->
             TargetDir = rebar_rel_utils:get_target_dir(ReltoolConfig),
             mk_target_dir(TargetDir),
 
+            %% Determine the otp root dir to use
+            RootDir = rebar_rel_utils:get_root_dir(ReltoolConfig),
+
             %% Dump the spec, if necessary
             dump_spec(Spec),
 
             %% Have reltool actually run
-            case reltool:eval_target_spec(Spec, code:root_dir(), TargetDir) of
+            case reltool:eval_target_spec(Spec, RootDir, TargetDir) of
                 ok ->
                     ok;
                 {error, Reason} ->


### PR DESCRIPTION
When generating a node using rebar generate, rebar always used code:root_dir() to find the Erlang installation to clone into the node tree.  However, for anyone wishing to build a cross-compiled node, there was no way to override this.  This patch adds a new option to reltool.config file to allow an alternate root_dir to be specified, for example:

``` erlang
{root_dir, "/tmp/otp_R14B03_armv7l"}
```

This assumes that the contents of /tmp/otp_R14B03_armv7l has been generated using the instructions found in the xcomp directory in your $ERL_TOP structure.  NOTE: you may have to add additional filters to exclude files not present in the xcomp version, such as the .smp files if you have disabled that.
