### PR TITLE
Don't run erl_args through set_trim

### DIFF
--- a/priv/templates/simplenode.windows.start_erl.cmd
+++ b/priv/templates/simplenode.windows.start_erl.cmd
@@ -4,7 +4,7 @@
 @rem Other args are position dependent.
 @set args="%*"
 @for /F "delims=++ tokens=1,2,3" %%I in (%args%) do @(
-    @call :set_trim erl_args %%I
+    @set erl_args=%%I
     @call :set_trim node_name %%J
     @call :set_trim node_root %%K
 )


### PR DESCRIPTION
Args provided by erlsrv.exe were being mostly discarded due to being processed through set_trim, causing serious headaches trying to connect distributed nodes.
