### PR TITLE
Dss env perf fix

### DIFF
--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -191,11 +191,11 @@ expand_env_variable(InStr, VarName, RawVarValue) ->
             %% No variables to expand
             InStr;
         _ ->
-            ReOpts = [global, {return, list}],
             VarValue = re:replace(RawVarValue, "\\\\", "\\\\\\\\", [global]),
             %% Use a regex to match/replace:
-            %% $FOO\s | ${FOO} | $FOO eol
+            %% Given variable "FOO": match $FOO\s | $FOOeol | ${FOO}
             RegEx = io_lib:format("\\\$(~s(\\s|$)|{~s})", [VarName, VarName]),
+            ReOpts = [global, {return, list}],
             re:replace(InStr, RegEx, VarValue ++ "\\2", ReOpts)
     end.
 


### PR DESCRIPTION
The introduction of setup_env as a global concept caused the rebar_port_compiler
implementation to start getting called a LOT. The expansion of environment variables
that happens in the port compiler was O(n^n), which means you could see upwards of
80k invocations of lists:foldl on a single app "./rebar clean". This commit reworks
the expansion to be O(n^2), and reduces the running time for the same operation by
60%+. On a large project like Riak, the end result is that a build went from 200
seconds to 73.
