### PR TITLE
treat HEAD as a branch to fix regressions caused by 3ef7db5

### DIFF
--- a/src/rebar_deps.erl
+++ b/src/rebar_deps.erl
@@ -352,9 +352,9 @@ download_source(AppDir, {hg, Url, Rev}) ->
                    [{cd, filename:dirname(AppDir)}]),
     rebar_utils:sh(?FMT("hg update ~s", [Rev]), [{cd, AppDir}]);
 download_source(AppDir, {git, Url}) ->
-    download_source(AppDir, {git, Url, "HEAD"});
+    download_source(AppDir, {git, Url, {branch, "HEAD"}});
 download_source(AppDir, {git, Url, ""}) ->
-    download_source(AppDir, {git, Url, "HEAD"});
+    download_source(AppDir, {git, Url, {branch, "HEAD"}});
 download_source(AppDir, {git, Url, {branch, Branch}}) ->
     ok = filelib:ensure_dir(AppDir),
     rebar_utils:sh(?FMT("git clone -n ~s ~s", [Url, filename:basename(AppDir)]),
@@ -400,9 +400,9 @@ update_source(Dep) ->
     end.
 
 update_source(AppDir, {git, Url}) ->
-    update_source(AppDir, {git, Url, "HEAD"});
+    update_source(AppDir, {git, Url, {branch, "HEAD"}});
 update_source(AppDir, {git, Url, ""}) ->
-    update_source(AppDir, {git, Url, "HEAD"});
+    update_source(AppDir, {git, Url, {branch, "HEAD"}});
 update_source(AppDir, {git, _Url, {branch, Branch}}) ->
     ShOpts = [{cd, AppDir}],
     rebar_utils:sh("git fetch origin", ShOpts),


### PR DESCRIPTION
The change in 3ef7db5 causes rebar_deps to execute "git checkout -q HEAD" instead of "git checkout -q origin/HEAD" for git dependencies specified as a 2-tuple or with a Rev of "".

"git checkout -q HEAD" is not equivalent to "git checkout -q origin/HEAD", in fact, it's pretty much useless. Specifically, it makes update-deps a no-op for us, which is not good!
