### PR TITLE
Stop applications nicely before killing extra processes

### DIFF
--- a/src/rebar_eunit.erl
+++ b/src/rebar_eunit.erl
@@ -484,9 +484,6 @@ reset_after_eunit({OldProcesses, WasAlive, OldAppEnvs, _OldACs}) ->
             ok
     end,
 
-    Processes = erlang:processes(),
-    _ = kill_extras(Processes -- OldProcesses),
-
     OldApps = [App || {App, _} <- OldAppEnvs],
     Apps = get_app_names(),
     _ = [begin
@@ -499,6 +496,10 @@ reset_after_eunit({OldProcesses, WasAlive, OldAppEnvs, _OldACs}) ->
                 {K, _V} <- application:get_all_env(App)],
 
     reconstruct_app_env_vars(Apps),
+
+    Processes = erlang:processes(),
+    _ = kill_extras(Processes -- OldProcesses),
+
     ok.
 
 kill_extras(Pids) ->


### PR DESCRIPTION
Hi,

(also posted on the rebar mailing list)

I came across a situation where my eunit tests left a started
application and I got this:

=INFO REPORT==== 31-Oct-2011::23:15:24 ===
   application: some_app_name
   exited: killed
   type: temporary

... and if I ran rebar with the -v flag also a number of "DEBUG: Kill"
printouts as well as a "Generic server... terminating" prinout.

Would it perhaps be better if rebar_eunit:reset_after_eunit/1 started
by shutting down applications, before moving on to killing processes?
I think so.  Then the applications would get a chance to clean up
after themselves.  The above prinout would change into this and -v
wouldn't show any extra kill messages:

=INFO REPORT==== 31-Oct-2011::23:11:33 ===
   application: some_app_name
   exited: stopped
   type: temporary

BR,
Klas
