### PR TITLE
Fix rebar_utils:expand_env_variable/3

### DIFF
--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -196,7 +196,7 @@ expand_env_variable(InStr, VarName, RawVarValue) ->
             %% Given variable "FOO": match $FOO\s | $FOOeol | ${FOO}
             RegEx = io_lib:format("\\\$(~s(\\s|$)|{~s})", [VarName, VarName]),
             ReOpts = [global, {return, list}],
-            re:replace(InStr, RegEx, VarValue ++ "\\2", ReOpts)
+            re:replace(InStr, RegEx, [VarValue, "\\2"], ReOpts)
     end.
 
 


### PR DESCRIPTION
The function may fail with a badarg exception because the first regex returns
an iolist() which is allowed to be a improper list. In this case '++' cannot
append to the iolist. The correct way to append something to an iolist() is

  [iolist(), "tail"]

because iolist's are allowed to be arbitrarily deep lists.
