### PR TITLE
Add support for importing/merging config

### DIFF
--- a/inttest/t_extend_config/extend_config.erl
+++ b/inttest/t_extend_config/extend_config.erl
@@ -1,0 +1,5 @@
+-module(extend_config).
+
+-compile(export_all).
+
+test() -> it.

--- a/inttest/t_extend_config/rebar.config
+++ b/inttest/t_extend_config/rebar.config
@@ -1,0 +1,7 @@
+
+{deps, [
+    {foobar, ".*"}
+]}.
+
+{erl_opts, [warnings_as_errors]}.
+{validate_app_modules, false}.

--- a/inttest/t_extend_config/t_extend_config_rt.erl
+++ b/inttest/t_extend_config/t_extend_config_rt.erl
@@ -1,0 +1,31 @@
+-module(t_extend_config_rt).
+
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+
+files() ->
+    [{copy, "rebar.config", "rebar.config"},
+     {copy, "test.config", "test.config"},
+     {create, "ebin/import_config.app", app(import_config, [import_config])}].
+
+run(Dir) ->
+    retest_log:log(debug, "Running in Dir: ~s~n", [Dir]),
+    Ref = retest:sh("rebar -C test.config check-deps -v", [{async, true}]),
+    {ok, _} = retest:sh_expect(Ref, "Dependency not available: foobar-.*",
+                               [{newline, any}]),
+    {ok, _} = retest:sh_expect(Ref, "Dependency not available: baz-.*",
+                              [{newline, any}]),
+    ok.
+
+%%
+%% Generate the contents of a simple .app file
+%%
+app(Name, Modules) ->
+    App = {application, Name,
+           [{description, atom_to_list(Name)},
+            {vsn, "1"},
+            {modules, Modules},
+            {registered, []},
+            {applications, [kernel, stdlib]}]},
+    io_lib:format("~p.\n", [App]).

--- a/inttest/t_extend_config/test.config
+++ b/inttest/t_extend_config/test.config
@@ -1,0 +1,6 @@
+
+{extend, "rebar.config"}.
+{deps, [
+    {baz, ".*"}
+]}.
+{erl_opts, [no_debug_info]}.

--- a/inttest/t_import_config/import_config.erl
+++ b/inttest/t_import_config/import_config.erl
@@ -1,0 +1,5 @@
+-module(import_config).
+
+-compile(export_all).
+
+test() -> it.

--- a/inttest/t_import_config/production.config
+++ b/inttest/t_import_config/production.config
@@ -1,0 +1,8 @@
+
+{import, "rebar.config"}.
+
+%% obviously in a real scenario you'd actually have some additional
+%% stuff in here - we just want to check that `import' works for now though
+
+%% frobble should *not* be checked, as `import' overwrites (unlike extend)
+{deps, [{frobble, ".*"}]}.

--- a/inttest/t_import_config/rebar.config
+++ b/inttest/t_import_config/rebar.config
@@ -1,0 +1,7 @@
+
+{deps, [
+    {foobar, ".*"}
+]}.
+
+{erl_opts, [warnings_as_errors]}.
+{validate_app_modules, true}.

--- a/inttest/t_import_config/t_import_config_rt.erl
+++ b/inttest/t_import_config/t_import_config_rt.erl
@@ -1,0 +1,32 @@
+-module(t_import_config_rt).
+
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+
+files() ->
+    [{copy, "rebar.config", "rebar.config"},
+     {copy, "production.config", "production.config"},
+     {create, "ebin/import_config.app", app(import_config, [import_config])}].
+
+run(Dir) ->
+    retest_log:log(debug, "Running in Dir: ~s~n", [Dir]),
+    Ref = retest:sh("rebar -C production.config list-deps -v", [{async, true}]),
+    {ok, _} = retest:sh_expect(Ref,
+            "ERROR: Missing dependencies: \\[\\{dep,bad_name,"
+            "foobar,\"\\.\\*\",undefined\\}\\]",
+            [{newline, any}]),
+    ok.
+
+%%
+%% Generate the contents of a simple .app file
+%%
+app(Name, Modules) ->
+    App = {application, Name,
+           [{description, atom_to_list(Name)},
+            {vsn, "1"},
+            {modules, Modules},
+            {registered, []},
+            {applications, [kernel, stdlib]}]},
+    io_lib:format("~p.\n", [App]).
+


### PR DESCRIPTION
Rebar allows you to store configuration in different files and select
the configuration you want to use using the -C <file> option. Currently
this leads to a lot of duplication however, so I've added the ability to
include configuration in two ways:

Importing is done using `{import, PathToConfig}`, which when processed
causes the incoming terms to _overwrite_ any existing ones. This allows
you to store common settings in one place.

Merging is done using `{extend, PathToConfig}`, which instead merges the
incoming configuration into the exiting one, rather than overwriting.
This merging of config is only applied to terms in the destination
config where the value (of a `{K,V}` tuple) is a list. Terms which map
to a scalar value are simply dropped from the incoming config set,
leaving the destination terms intact.

This allows you to, for example, have base config settings (such as
`deps` or `erl_opts`) declared in your main `rebar.config` but declare
additional test `deps` (etc) in `test.config` and have the two get merged.
