### PR TITLE
Make 'rebar xref' honour the skip_app directive

### DIFF
--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -43,7 +43,9 @@
          prop_check/3,
          expand_code_path/0,
          deprecated/5,
-         expand_env_variable/3]).
+         expand_env_variable/3,
+         is_skipped_app/0
+        ]).
 
 -include("rebar.hrl").
 
@@ -197,6 +199,42 @@ expand_env_variable(InStr, VarName, RawVarValue) ->
             RegEx = io_lib:format("\\\$(~s(\\s|$)|{~s})", [VarName, VarName]),
             ReOpts = [global, {return, list}],
             re:replace(InStr, RegEx, [VarValue, "\\2"], ReOpts)
+    end.
+
+%%
+%% Return: true , if we are in the context of a 'Skipped App', else: false
+%% (Example: rebar xref skip_app=mochiweb,webmachine)
+is_skipped_app() ->
+    case rebar_config:get_global(skip_app, undefined) of
+        undefined ->
+            %% no skip list
+            false;
+
+        SkipApps ->
+
+            case string:tokens(SkipApps, ",") of
+                [] ->
+                    %% no tokens
+                    false;
+
+                SkipAppsTokens ->
+
+                    %% Where we are at the moment
+                    Cwd = rebar_utils:get_cwd(),
+
+                    %% Return true if app should be skipped
+                    SkipPred = fun(App) ->
+                                       case re:run(Cwd, App) of
+                                           {match,_} -> true;
+                                           _         -> false
+                                       end
+                               end,
+
+                    %% Check if 'we' are among the skipped apps.
+                    lists:foldl(fun(SkippedApp, Bool) ->
+                                        SkipPred(SkippedApp) or Bool
+                                end, false, SkipAppsTokens)
+            end
     end.
 
 

--- a/src/rebar_xref.erl
+++ b/src/rebar_xref.erl
@@ -40,7 +40,13 @@
 %% Public API
 %% ===================================================================
 
-xref(Config, _) ->
+xref(Config, _X) ->
+    case rebar_utils:is_skipped_app() of
+        true  -> ok;
+        false -> xref0(Config, _X)
+    end.
+            
+xref0(Config, _) ->
     %% Spin up xref
     {ok, _} = xref:start(xref),
     ok = xref:set_library_path(xref, code_path()),
@@ -199,3 +205,4 @@ find_mfa_source({M, F, A}) ->
         %% parameterized modules add new/1 and instance/1 for example.
         [] -> {Source, function_not_found}
     end.
+


### PR DESCRIPTION
It is now possible to call rebar as:

  rebar xref skip_app=Mod1,Mod2,...

This makes it easy to skip running xref on (e.g)
imported dependencies in your application.

The function rebar_utils:is_skipped_app/0 is added so
that other rebar commands may use it.

NB: This is a new branch with some modifications suggested by Tuncer.
