### PR TITLE
Cleanup .erl files from .eunit folder before running eunit

### DIFF
--- a/src/rebar_eunit.erl
+++ b/src/rebar_eunit.erl
@@ -98,7 +98,7 @@ eunit(Config, _AppFile) ->
         F2 = filename:basename(F),
         F3 = filename:join([?EUNIT_DIR, F2]),
         case filelib:is_regular(F3) of
-           true -> Acc ++ [F3];
+           true -> [F3|Acc];
            false -> Acc
         end
     end,


### PR DESCRIPTION
Before copying the .erl files to the .eunit directory ensure that they are deleted if they already exist. This prevents EACCES errors from happening when trying to re-copy .erl files that are read-only.

There is an issue with SCMs that leave files as being "read-only" unless they are explicitly checked-out (for example, Perforce works like that).

In my case, all files under src/ were not writable. Running "./rebar eunit" the first time would work but it wouldn't work on subsequent attempts since the copied files under .eunit/ were not writable. What happened was that rebar caught EACCES errors whenever executing rebar_file_utils:cp_r on unwritable files.

This patch tries to find the matching files under .eunit and removes them before calling rebar_file_utils:cp_r.

Thanks,
Francis
