### PR TITLE
add ability to put options on deps and implement alt_url option for git

### DIFF
--- a/priv/shell-completion/bash/rebar
+++ b/priv/shell-completion/bash/rebar
@@ -12,7 +12,8 @@ _rebar()
         ct doc delete-deps eunit get-deps generate generate-upgrade \
         help list-deps list-templates update-deps version xref overlay \
         apps= case= force=1 jobs= suites= verbose=1 appid= previous_release= \
-        nodeid= root_dir= skip_deps=true skip_apps= template= template_dir="
+        nodeid= root_dir= skip_deps=true skip_apps= template= template_dir= \
+        alt_urls=true"
 
     if [[ ${cur} == --* ]] ; then
         COMPREPLY=( $(compgen -W "${lopts}" -- ${cur}) )

--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -113,7 +113,10 @@
 {deps, [application_name,
         {application_name, "1.0.*"},
         {application_name, "1.0.*",
-         {git, "git://github.com/basho/rebar.git", {branch, "master"}}}]}.
+         {git, "git://github.com/basho/rebar.git", {branch, "master"}}},
+        {application_name, "1.0.*",
+         {git, "git://github.com/basho/rebar.git", {branch, "master"}},
+         [{alt_url, "https://github.com/basho/rebar.git"}]}]}.
 
 %% == Subdirectories ==
 


### PR DESCRIPTION
added the ability to put options on a rebar dep. Also implemented the alt_url option for git deps so that if you fail to retrieve it using the primary URL it falls back onto the alternate.

This is sometimes needed when firewalls block the git:// port.
