### PR TITLE
Error report killing inet_gethost_native after eunit

### DIFF
--- a/src/rebar_eunit.erl
+++ b/src/rebar_eunit.erl
@@ -477,7 +477,11 @@ kill_extras(Pids) ->
     %% This list may require changes as OTP versions and/or
     %% rebar use cases change.
     KeepProcs = [cover_server, eunit_server,
-                 eqc, eqc_license, eqc_locked],
+                 eqc, eqc_license, eqc_locked,
+                 %% inet_gethost_native is started on demand, when
+                 %% doing name lookups. It is under kernel_sup, under
+                 %% a supervisor_bridge.
+                 inet_gethost_native],
     Killed = [begin
                   Info = case erlang:process_info(Pid) of
                              undefined -> [];


### PR DESCRIPTION
This is a change to not kill the inet_gethost_native process. That process is started on demand to do name lookups, so it might well happen that it is started by an eunit test case. If so, the cleanup after eunit will kill it, producing printouts like this one:

<pre>
  prompt$ rebar eunit
  ==> dummy (eunit)
    Test passed.

  =ERROR REPORT==== 29-Dec-2011::23:22:11 ===
  ** Generic server inet_gethost_native_sup terminating
  ** Last message in was {'EXIT',<0.62.0>,killed}
  ** When Server state == {state,inet_gethost_native,undefined,<0.62.0>,
                                 {local,inet_gethost_native_sup}}
  ** Reason for termination ==
  ** killed
</pre>


The following test case is sufficient to provoke the printout above:

<pre>
  x_test() ->
      {ok, _Hostent} = inet:gethostbyname(localhost).
</pre>


BRs
Tomas
