### PR TITLE
Fix template render with boolean values

### DIFF
--- a/src/mustache.erl
+++ b/src/mustache.erl
@@ -169,6 +169,10 @@ get(Key, Ctx, Mod) when is_list(Key) ->
   get(list_to_atom(Key), Ctx, Mod);
 get(Key, Ctx, Mod) ->
   case dict:find(Key, Ctx) of
+    {ok, true} ->
+      true;
+    {ok, false} ->
+      false;
     {ok, Val} ->
       % io:format("From Ctx {~p, ~p}~n", [Key, Val]),
       to_s(Val);


### PR DESCRIPTION
Fixes support of key/value pairs such as {foo, true}.

mustache.erl seems to expect functions for boolean sections, which isn't practical for rebar. This is the simplest fix I found.
