### PR TITLE
Allow reltool target_dir to be constructed on the fly

### DIFF
--- a/src/rebar_reltool.erl
+++ b/src/rebar_reltool.erl
@@ -224,6 +224,7 @@ run_reltool(Server, _Config, ReltoolConfig) ->
 
 
 mk_target_dir(TargetDir) ->
+    ok = filelib:ensure_dir(filename:join(TargetDir,"foo")),
     case file:make_dir(TargetDir) of
         ok ->
             ok;


### PR DESCRIPTION
The version info in reltool.config can already be expanded by rebar.
This patch makes it possible to use release name and version info to
dynamically construct a target_dir. The patterns $(name) and $(vsn)
are automatically expanded to the corresponding values in RelToolConfig.

For example:

{target_dir, "$(name)/$(vsn)"}

would result in a target directory like "rel/mynode/2.2.1".
