### PR TITLE
rebar should expand VCS version in the top directory, if possible

### DIFF
--- a/src/rebar_rel_utils.erl
+++ b/src/rebar_rel_utils.erl
@@ -219,7 +219,12 @@ expand_version(ReltoolConfig, Dir) ->
     end.
 
 expand_rel_version({rel, Name, Version, Apps}, Dir) ->
-    Base = rebar_config:get_global(base_dir, Dir),
-    {rel, Name, rebar_utils:vcs_vsn(Version, Base), Apps};
+    UseDir = case rebar_config:get_global(skip_deps, false) of
+                 "true" ->
+                     rebar_config:get_global(base_dir, Dir);
+                 _ ->
+                     Dir
+             end,
+    {rel, Name, rebar_utils:vcs_vsn(Version, UseDir), Apps};
 expand_rel_version(Other, _Dir) ->
     Other.


### PR DESCRIPTION
When a VCS tag is present in the reltool.config file, rebar tries
to expand it. However, it does so in the rel/ directory, which
(at least for git) may not reveal the latest version.

A problem is that if rebar was called with `cd rel; rebar generate`,
rebar will not know what the top directory is. This can be solved
by instead running `rebar generate skip_deps=true` from the top
directory. This patch makes rebar_rel_utils use base_dir instead
of the directory of reltool.config.
