### PR TITLE
Common Test changes to add configurable log dir and improve testing framework overlaps.

### DIFF
--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -83,8 +83,11 @@
 
 %% == Common Test ==
 
-%% Override the default "test" directory in which SUITEs are located
-{ct_dir, "itest"}.
+%% Override the default "ctest" directory in which SUITEs are located
+{ct_dir, "ctest"}.
+
+%% Override the default "logs" directory in which SUITEs are logged
+{ct_logs, "logs"}.
 
 %% Option to pass extra parameters when launching Common Test
 {ct_extra_params, "-boot start_sasl -s myapp"}.

--- a/src/rebar_ct.erl
+++ b/src/rebar_ct.erl
@@ -46,24 +46,25 @@
 %% ===================================================================
 
 ct(Config, File) ->
-    TestDir = rebar_config:get_local(Config, ct_dir, "test"),
-    run_test_if_present(TestDir, Config, File).
+    TestDir = rebar_config:get_local(Config, ct_dir, "ctest"),
+    LogsDir = rebar_config:get_local(Config, ct_logs, "logs"),
+    run_test_if_present(TestDir, LogsDir, Config, File).
 
 %% ===================================================================
 %% Internal functions
 %% ===================================================================
-run_test_if_present(TestDir, Config, File) ->
+run_test_if_present(TestDir, LogsDir, Config, File) ->
     case filelib:is_dir(TestDir) of
         false ->
             ?WARN("~s directory not present - skipping\n", [TestDir]),
             ok;
         true ->
-            run_test(TestDir, Config, File)
+            run_test(TestDir, LogsDir, Config, File)
     end.
 
-run_test(TestDir, Config, _File) ->
-    {Cmd, RawLog} = make_cmd(TestDir, Config),
-    clear_log(RawLog),
+run_test(TestDir, LogsDir, Config, _File) ->
+    {Cmd, RawLog} = make_cmd(TestDir, LogsDir, Config),
+    clear_log(LogsDir, RawLog),
     case rebar_config:is_verbose() of
         false ->
             Output = " >> " ++ RawLog ++ " 2>&1";
@@ -75,8 +76,8 @@ run_test(TestDir, Config, _File) ->
     check_log(RawLog).
 
 
-clear_log(RawLog) ->
-    case filelib:ensure_dir("logs/index.html") of
+clear_log(LogsDir, RawLog) ->
+    case filelib:ensure_dir(filename:join(LogsDir, "index.html")) of
         ok ->
             NowStr = rebar_utils:now_str(),
             LogHeader = "--- Test run on " ++ NowStr ++ " ---\n",
@@ -120,9 +121,9 @@ show_log(RawLog) ->
             ok
     end.
 
-make_cmd(TestDir, Config) ->
+make_cmd(TestDir, LogsDir, Config) ->
     Cwd = rebar_utils:get_cwd(),
-    LogDir = filename:join(Cwd, "logs"),
+    LogDir = filename:join(Cwd, LogsDir),
     EbinDir = filename:absname(filename:join(Cwd, "ebin")),
     IncludeDir = filename:join(Cwd, "include"),
     Include = case filelib:is_dir(IncludeDir) of


### PR DESCRIPTION
If you dont restrict rebar ct with skip_deps=true it'll create ct log file dirs in all of the deps directories that contain a test/ directory, when they are clearly only for eunit and contain no common test SUITES. 

Furthermore the logs dir parameters in the test specs are ignored and hardcoded in rebar_ct.
This pull request defines ctest as the common test directory, and adds a {ct_logs, ..} configurable option.
