### PR TITLE
Cache vsn information during the run to avoid extra unnecessary shell calls

### DIFF
--- a/src/rebar.erl
+++ b/src/rebar.erl
@@ -96,6 +96,9 @@ run_aux(Commands) ->
     %% Initialize logging system
     rebar_log:init(),
 
+    %% Initialize vsn cache
+    _VsnCacheTab = ets:new(rebar_vsn_cache,[named_table, public]),
+
     %% Convert command strings to atoms
     CommandAtoms = [list_to_atom(C) || C <- Commands],
 

--- a/src/rebar_core.erl
+++ b/src/rebar_core.erl
@@ -90,6 +90,9 @@ process_commands([Command | Rest], ParentConfig) ->
         _ ->
             ok
     end,
+    %% Wipe out vsn cache to avoid invalid hits when
+    %% dependencies are updated
+    ets:delete_all_objects(rebar_vsn_cache),
     process_commands(Rest, ParentConfig).
 
 

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -189,6 +189,17 @@ expand_env_variable(InStr, VarName, RawVarValue) ->
     end.
 
 vcs_vsn(Vcs, Dir) ->
+    Key = {Vcs, Dir},
+    case ets:lookup(rebar_vsn_cache, Key) of
+        [{Key, VsnString}] ->
+            VsnString;
+        [] ->
+            VsnString = vcs_vsn_1(Vcs, Dir),
+            ets:insert(rebar_vsn_cache, {Key, VsnString}),
+            VsnString
+    end.
+
+vcs_vsn_1(Vcs, Dir) ->            
     case vcs_vsn_cmd(Vcs) of
         {unknown, VsnString} ->
             ?DEBUG("vcs_vsn: Unknown VCS atom in vsn field: ~p\n", [Vcs]),


### PR DESCRIPTION
My experiments showed that I can save a lot of time compiling a complex project by caching vsn information.

Here's the original up-to-date rebar timing (no compilation incurred, everything is up-to-date):

```
11.26s user 1.77s system 106% cpu 12.277 total
```

And here's after this patch:

```
6.47s user 0.78s system 113% cpu 6.364 total
```

Please consider merging it in.
