### PR TITLE
Remove dependent from source

### DIFF
--- a/src/rebar_reltool.erl
+++ b/src/rebar_reltool.erl
@@ -31,7 +31,6 @@
          clean/2]).
 
 -include("rebar.hrl").
--include_lib("reltool/src/reltool.hrl").
 -include_lib("kernel/include/file.hrl").
 
 %% ===================================================================


### PR DESCRIPTION
In some systems (Ubuntu 8.04) in Erlang package source code is not included. Because of this, when compiling rebar error occurs.

Simply remove the include of reltool.hrl and everything works fine.
