### PR TITLE
Add ebin to the path before compiling erlydtl templates

### DIFF
--- a/src/rebar_erlydtl_compiler.erl
+++ b/src/rebar_erlydtl_compiler.erl
@@ -82,6 +82,7 @@
 
 compile(Config, _AppFile) ->
     DtlOpts = erlydtl_opts(Config),
+    true = code:add_path(filename:join(rebar_utils:get_cwd(), "ebin")),
     rebar_base_compiler:run(Config, [],
                             option(doc_root, DtlOpts),
                             option(source_ext, DtlOpts),


### PR DESCRIPTION
The latest version of erlydtl requires that custom tag modules be in the path when templates are compiled. Without this change rebar silently exits when using the custom_tags_modules option.
