### PR TITLE
Make rebar understand wildcard in subdir

### DIFF
--- a/src/rebar_subdirs.erl
+++ b/src/rebar_subdirs.erl
@@ -38,7 +38,8 @@
 preprocess(Config, _) ->
     %% Get the list of subdirs specified in the config (if any).
     Cwd = rebar_utils:get_cwd(),
-    Subdirs0 = rebar_config:get_local(Config, sub_dirs, []),
+    ListSubdirs = rebar_config:get_local(Config, sub_dirs, []),
+    Subdirs0 = lists:flatmap(fun filelib:wildcard/1, ListSubdirs),
     case {rebar_core:is_skip_dir(Cwd), Subdirs0} of
         {true, []} ->
             {ok, []};


### PR DESCRIPTION
If you have dir with many erlang app, then you can simple write
{sub_dirs, ["some_dir/*"]}. Rebar will make operation on subdirs of
dir "some_dir".
