### PR TITLE
fix for cp_r_win32 where copying a directory to a non-existant directory would crash

### DIFF
--- a/src/rebar_file_utils.erl
+++ b/src/rebar_file_utils.erl
@@ -150,6 +150,24 @@ cp_r_win32({false, Source},{false, Dest}) ->
     %% from file to file
     {ok,_} = file:copy(Source, Dest),
     ok;
+cp_r_win32({true, SourceDir},{false,DestDir}) -> 
+    IsFile = filelib:is_file(DestDir),
+    case IsFile of
+        true -> 
+            %% From Directory to file? This shouldn't happen
+            {error,[{rebar_file_utils,cp_r_win32},
+                        {directory_to_file_makes_no_sense,
+                            {source,SourceDir},{dest,DestDir}}]};
+        false ->
+            %% Specifying a target directory that doesn't currently exist.
+            %% So Let's attempt to create this directory
+            %% Will not recursively create parent directories
+            ok = case file:make_dir(DestDir) of
+                     {error, eexist} -> ok;
+                     Other -> Other
+                 end,
+            ok = xcopy_win32(SourceDir, DestDir)
+    end;
 cp_r_win32(Source,Dest) ->
     Dst = {filelib:is_dir(Dest), Dest},
     lists:foreach(fun(Src) ->


### PR DESCRIPTION
Hi!

Previously, on windows, rebar_file_utils:cp_r_win32 would throw an error copying a directory to a non-existant directory where linux would handle it just fine.

Example from a reltool (assuming site/static exists, but is empty):

``` erlang
{copy,  "../deps/nitrogen_core/www", "site/static/nitrogen"},
```

On linux, this would work, properly copying "../deps/nitrogen_core/www" to "site/static/nitrogen", creating the "nitrogen" directory in the process.  On windows, it would crash because nitrogen didn't exist.  This patch fixes that, and will allow it to more closely simulate the linux experience.

To be more specific, for the function call matching

``` erlang
cp_r_win32({true,SourceDir},{false,DestDir})
```

It would fail, since DestDir was previously checked to be a dir (first line of cp_r_win32(Source,Dest) ) and since it didn't exist, it's also not a Dir. My fix here accounts for that and if it's determined to also not be a file, then it doesn't exist and it attempts to make the directory to copy into.

Thanks,

-Jesse
