### PR TITLE
Fix runner

### DIFF
--- a/priv/templates/simplenode.runner
+++ b/priv/templates/simplenode.runner
@@ -74,7 +74,7 @@ case "$1" in
         fi
         shift # remove $1
         RUN_PARAM=$(printf "\'%s\' " "$@")
-        HEART_COMMAND="$RUNNER_BASE_DIR/bin/$SCRIPT start"
+        HEART_COMMAND="$RUNNER_BASE_DIR/bin/$SCRIPT start $RUN_PARAM"
         export HEART_COMMAND
         mkdir -p $PIPE_DIR
         $ERTS_PATH/run_erl -daemon $PIPE_DIR $RUNNER_LOG_DIR "exec $RUNNER_BASE_DIR/bin/$SCRIPT console $RUN_PARAM" 2>&1


### PR DESCRIPTION
If you try bin/<release_name> console -kernel test '[{"a","b"}]' you will fail, because when $@ inserted into CMD [{"a","b"}] interpreted as command.
Moved insert parametrs from CMD into run of exec.

Similar with bin/<release-name> start -kernel test '[{"a","b"}]'.
Quote in ' all parametrs after start and passed it to erlexec.

For correct re-run by heart it is better to save parameters that used for first start node.
