### PR TITLE
Escape '|' in the Windows runner usage string

### DIFF
--- a/priv/templates/simplenode.windows.runner.cmd
+++ b/priv/templates/simplenode.windows.runner.cmd
@@ -27,7 +27,7 @@
 @rem TODO: attach, ping, restart and reboot
 
 :usage
-@echo Usage: %0 {install|uninstall|start|stop|restart|console}
+@echo Usage: %0 {install^|uninstall^|start^|stop^|restart^|console}
 @goto :EOF
 
 :install


### PR DESCRIPTION
The Windows simplenode runner template prints a usage string that
contains the pipe character '|'. That character needs to be escaped with
a caret '^' otherwise the script will try to perform shell command
piping when printing its usage. Tested on Windows 7.
