### PR TITLE
Enable runner to pass more than one argument to start

### DIFF
--- a/priv/templates/simplenode.runner
+++ b/priv/templates/simplenode.runner
@@ -76,7 +76,8 @@ case "$1" in
         export HEART_COMMAND
         mkdir -p $PIPE_DIR
         shift # remove $1
-        $ERTS_PATH/run_erl -daemon $PIPE_DIR $RUNNER_LOG_DIR "exec $RUNNER_BASE_DIR/bin/$SCRIPT console $@" 2>&1
+        ARGS=$@
+        $ERTS_PATH/run_erl -daemon $PIPE_DIR $RUNNER_LOG_DIR "exec $RUNNER_BASE_DIR/bin/$SCRIPT console $ARGS" 2>&1
         ;;
 
     stop)


### PR DESCRIPTION
The entire exec command, including all args, should be passed as one parameter
to run_erl. Including $@ in a quoted string doesn't work, but assigning it to
a different variable and using that does.
