### PR TITLE
Fix a badarg crash on the missing erlydtl error

### DIFF
--- a/src/rebar_abnfc_compiler.erl
+++ b/src/rebar_abnfc_compiler.erl
@@ -85,12 +85,12 @@ compile_abnfc(Source, _Target, Config) ->
     case abnfc_is_present() of
         false ->
             ?ERROR(
-               <<"~n===============================================~n"
+                 "~n===============================================~n"
                  " You need to install abnfc to compile ABNF grammars~n"
                  " Download the latest tarball release from github~n"
                  "    https://github.com/nygge/abnfc~n"
                  " and install it into your erlang library dir~n"
-                 "===============================================~n~n">>, []),
+                 "===============================================~n~n", []),
             ?FAIL;
         true ->
             AbnfcOpts = abnfc_opts(Config),

--- a/src/rebar_erlydtl_compiler.erl
+++ b/src/rebar_erlydtl_compiler.erl
@@ -114,12 +114,12 @@ compile_dtl(Source, Target, Config) ->
     case code:which(erlydtl) of
         non_existing ->
             ?ERROR(
-               <<"~n===============================================~n"
+                 "~n===============================================~n"
                  " You need to install erlydtl to compile DTL templates~n"
                  " Download the latest tarball release from github~n"
                  "    http://code.google.com/p/erlydtl/~n"
                  " and install it into your erlang library dir~n"
-                 "===============================================~n~n">>, []),
+                 "===============================================~n~n", []),
             ?FAIL;
         _ ->
             case needs_compile(Source, Target, Config) of

--- a/src/rebar_lfe_compiler.erl
+++ b/src/rebar_lfe_compiler.erl
@@ -48,17 +48,15 @@ compile(Config, _AppFile) ->
 compile_lfe(Source, _Target, Config) ->
     case code:which(lfe_comp) of
         non_existing ->
-            ?ERROR(<<
-                     "~n"
-                     "*** MISSING LFE COMPILER ***~n"
-                     "  You must do one of the following:~n"
-                     "    a) Install LFE globally in your erl libs~n"
-                     "    b) Add LFE as a dep for your project, eg:~n"
-                     "       {lfe, \"0.6.1\",~n"
-                     "        {git, \"git://github.com/rvirding/lfe\",~n"
-                     "         {tag, \"v0.6.1\"}}}~n"
-                     "~n"
-                   >>, []),
+            ?ERROR("~n"
+                   "*** MISSING LFE COMPILER ***~n"
+                   "  You must do one of the following:~n"
+                   "    a) Install LFE globally in your erl libs~n"
+                   "    b) Add LFE as a dep for your project, eg:~n"
+                   "       {lfe, \"0.6.1\",~n"
+                   "        {git, \"git://github.com/rvirding/lfe\",~n"
+                   "         {tag, \"v0.6.1\"}}}~n"
+                   "~n", []),
             ?FAIL;
         _ ->
             Opts = [{i, "include"}, {outdir, "ebin"}, report]

--- a/src/rebar_neotoma_compiler.erl
+++ b/src/rebar_neotoma_compiler.erl
@@ -75,12 +75,12 @@ compile_neo(Source, Target, Config) ->
     case code:which(neotoma) of
         non_existing ->
             ?ERROR(
-               <<"~n===============================================~n"
+                 "~n===============================================~n"
                  " You need to install neotoma to compile PEG grammars~n"
                  " Download the latest tarball release from github~n"
                  "    https://github.com/seancribbs/neotoma~n"
                  " and install it into your erlang library dir~n"
-                 "===============================================~n~n">>, []),
+                 "===============================================~n~n", []),
             ?FAIL;
         _ ->
             case needs_compile(Source, Target, Config) of


### PR DESCRIPTION
At least on R14B04, io:format accepts either strings or binaries,
but not iolists. ?ERROR adds a string at the beginning of the Format,
creating an iolist, which ends up crashing io:format.

Original error with rebar -vvv:

```
DEBUG: Worker compilation failed: [{error,
                                    {'EXIT',
                                     {badarg,
                                      [{io,format,
                                        [<0.23.0>,
                                         [69,82,82,79,82,58,32|
                                          <<"~n===============================================~n You need to install erlydtl to compile DTL templates~n Download the latest tarball release from github~n    http://code.google.com/p/erlydtl/~n and install it into your erlang library dir~n===============================================~n~n">>],
                                         []]},
                                       {rebar_erlydtl_compiler,compile_dtl,3},
                                       {rebar_base_compiler,compile,3},
                                       {rebar_base_compiler,compile_worker,
                                        3}]}}},
                                   {source,"templates/toppage.dtl"}]
```
