### PR TITLE
Added rsync as an option to fetch dependencies

### DIFF
--- a/src/rebar_deps.erl
+++ b/src/rebar_deps.erl
@@ -379,7 +379,10 @@ download_source(AppDir, {svn, Url, Rev}) ->
     ok = filelib:ensure_dir(AppDir),
     rebar_utils:sh(?FMT("svn checkout -r ~s ~s ~s",
                         [Rev, Url, filename:basename(AppDir)]),
-                   [{cd, filename:dirname(AppDir)}]).
+                   [{cd, filename:dirname(AppDir)}]);
+download_source(AppDir, {rsync, Url}) ->
+    ok = filelib:ensure_dir(AppDir),
+    rebar_utils:sh(?FMT("rsync -az --delete ~s/ ~s",[Url,AppDir]),[]).
 
 update_source(Dep) ->
     %% It's possible when updating a source, that a given dep does not have a
@@ -420,7 +423,10 @@ update_source(AppDir, {svn, _Url, Rev}) ->
 update_source(AppDir, {hg, _Url, Rev}) ->
     rebar_utils:sh(?FMT("hg pull -u -r ~s", [Rev]), [{cd, AppDir}]);
 update_source(AppDir, {bzr, _Url, Rev}) ->
-    rebar_utils:sh(?FMT("bzr update -r ~s", [Rev]), [{cd, AppDir}]).
+    rebar_utils:sh(?FMT("bzr update -r ~s", [Rev]), [{cd, AppDir}]);
+update_source(AppDir, {rsync, Url}) ->
+    rebar_utils:sh(?FMT("rsync -az --delete ~s/ ~s",[Url,AppDir]),[]).
+
 
 
 
@@ -433,7 +439,7 @@ source_engine_avail(Source) ->
     source_engine_avail(Name, Source).
 
 source_engine_avail(Name, Source)
-  when Name == hg; Name == git; Name == svn; Name == bzr ->
+  when Name == hg; Name == git; Name == svn; Name == bzr; Name == rsync ->
     case vcs_client_vsn(Name) >= required_vcs_client_vsn(Name) of
         true ->
             true;
@@ -454,10 +460,11 @@ vcs_client_vsn(Path, VsnArg, VsnRegex) ->
             false
     end.
 
-required_vcs_client_vsn(hg)  -> {1, 1};
-required_vcs_client_vsn(git) -> {1, 5};
-required_vcs_client_vsn(bzr) -> {2, 0};
-required_vcs_client_vsn(svn) -> {1, 6}.
+required_vcs_client_vsn(hg)    -> {1, 1};
+required_vcs_client_vsn(git)   -> {1, 5};
+required_vcs_client_vsn(bzr)   -> {2, 0};
+required_vcs_client_vsn(svn)   -> {1, 6};
+required_vcs_client_vsn(rsync) -> {2, 0}. 
 
 vcs_client_vsn(hg) ->
     vcs_client_vsn(rebar_utils:find_executable("hg"), " --version",
@@ -470,7 +477,10 @@ vcs_client_vsn(bzr) ->
                    "Bazaar \\(bzr\\) (\\d+).(\\d+)");
 vcs_client_vsn(svn) ->
     vcs_client_vsn(rebar_utils:find_executable("svn"), " --version",
-                   "svn, version (\\d+).(\\d+)").
+                   "svn, version (\\d+).(\\d+)");
+vcs_client_vsn(rsync) ->
+    vcs_client_vsn(rebar_utils:find_executable("rsync"), " --version",
+                   "rsync  version (\\d+).(\\d+)").
 
 has_vcs_dir(git, Dir) ->
     filelib:is_dir(filename:join(Dir, ".git"));
@@ -481,6 +491,8 @@ has_vcs_dir(bzr, Dir) ->
 has_vcs_dir(svn, Dir) ->
     filelib:is_dir(filename:join(Dir, ".svn"))
         orelse filelib:is_dir(filename:join(Dir, "_svn"));
+has_vcs_dir(rsync, _) ->
+    true;
 has_vcs_dir(_, _) ->
     true.
 


### PR DESCRIPTION
Sometimes dependent applications are not in their separate VC repo. They could be in just a folder in one larger git repository or on another machine accessible via ssh.  

I added an option to use rsync to fetch dependencies.

For example, If there is one git repo that has inside of it in some folder a couple of applications:

 .../
   cowboy/
   proper/
   <other apps> 

Then _cowboy_ can now use this in its rebar.config file:

``` erlang
{deps, [
    {proper, "1.0", {rsync, "../proper"}}
]}.
```

rsync option accepts one URL arg. It can be a relative path, absolute path, rsync://, ssh:// or any other protocol that rsync supports.

NOTE: If there are transitive dependencies, relative paths to dependencies would be broken. Because once a application has been copied in 'deps' folder of another, its own relative dependencies don't point to where they should anymore). 

For this reason there is also the option to use $gitroot or $hgroot at the start of rsync urls paths. So if the above example was in some git repository, laid out like this:

<gitroot>/erlang-apps/
  cowboy/
  proper/

Then _cowboy_ can specify _proper_ as its dependency using:

``` erlang
{deps, [
{proper, "1.0", {rsync, "$gitroot/erlang-apps/proper"}}
]}.
```
