### PR TITLE
ASN1 compiler issue

### DIFF
--- a/src/rebar_asn1_compiler.erl
+++ b/src/rebar_asn1_compiler.erl
@@ -58,8 +58,12 @@ compile_asn1(Source, Target, Config) ->
         ok ->
             Asn1 = filename:basename(Source, ".asn1"),
             HrlFile = filename:join("src", Asn1 ++ ".hrl"),
-            ok = rebar_file_utils:mv(HrlFile, "include"),
-            ok;
+            case filelib:is_file(HrlFile) of
+                true ->
+                    ok = rebar_file_utils:mv(HrlFile, "include");
+                false ->
+                    ok
+            end;
         {error, _Reason} ->
             ?FAIL
     end.


### PR DESCRIPTION
Check for the existence of hrl files before trying to move it to include/ directory during ASN1 compilation
since ASN1 files doesn't necessarily produce hrl files.
