### PR TITLE
    Modified simplenode.runner to start from alternative directory

### DIFF
--- a/priv/templates/simplenode.runner
+++ b/priv/templates/simplenode.runner
@@ -4,9 +4,10 @@
 
 RUNNER_SCRIPT_DIR=$(cd ${0%/*} && pwd)
 
+CALLER_DIR=$PWD
+
 RUNNER_BASE_DIR=${RUNNER_SCRIPT_DIR%/*}
 RUNNER_ETC_DIR=$RUNNER_BASE_DIR/etc
-RUNNER_LOG_DIR=$RUNNER_BASE_DIR/log
 # Note the trailing slash on $PIPE_DIR/
 PIPE_DIR=/tmp/$RUNNER_BASE_DIR/
 RUNNER_USER=
@@ -16,11 +17,6 @@ if [ ! -z "$RUNNER_USER" ] && [ `whoami` != "$RUNNER_USER" ]; then
     exec sudo -u $RUNNER_USER -i $0 $@
 fi
 
-# Make sure CWD is set to runner base dir
-cd $RUNNER_BASE_DIR
-
-# Make sure log directory exists
-mkdir -p $RUNNER_LOG_DIR
 # Identify the script name
 SCRIPT=`basename $0`
 
@@ -29,18 +25,32 @@ START_ERL=`cat $RUNNER_BASE_DIR/releases/start_erl.data`
 ERTS_VSN=${START_ERL% *}
 APP_VSN=${START_ERL#* }
 
-# Use releases/VSN/vm.args if it exists otherwise use etc/vm.args
-if [ -e "$RUNNER_BASE_DIR/releases/$APP_VSN/vm.args" ]; then
-    VMARGS_PATH="$RUNNER_BASE_DIR/releases/$APP_VSN/vm.args"
+# Use $CWD/vm.args if exists, otherwise releases/VSN/vm.args, then etc/vm.args
+if [ -e "$CALLER_DIR/vm.args" ]; then
+    VMARGS_PATH=$CALLER_DIR/vm.args
+    USE_DIR=$CALLER_DIR
 else
-    VMARGS_PATH="$RUNNER_ETC_DIR/vm.args"
+    USE_DIR=$RUNNER_BASE_DIR
+    if [ -e "$RUNNER_BASE_DIR/releases/$APP_VSN/vm.args" ]; then
+        VMARGS_PATH="$RUNNER_BASE_DIR/releases/$APP_VSN/vm.args"
+    else
+        VMARGS_PATH="$RUNNER_ETC_DIR/vm.args"
+    fi
 fi
 
+RUNNER_LOG_DIR=$USE_DIR/log
+# Make sure log directory exists
+mkdir -p $RUNNER_LOG_DIR
+
 # Use releases/VSN/sys.config if it exists otherwise use etc/app.config
-if [ -e "$RUNNER_BASE_DIR/releases/$APP_VSN/sys.config" ]; then
-    CONFIG_PATH="$RUNNER_BASE_DIR/releases/$APP_VSN/sys.config"
+if [ -e "$USE_DIR/sys.config" ]; then
+    CONFIG_PATH="$USE_DIR/sys.config"
 else
-    CONFIG_PATH="$RUNNER_ETC_DIR/app.config"
+    if [ -e "$RUNNER_BASE_DIR/releases/$APP_VSN/sys.config" ]; then
+        CONFIG_PATH="$RUNNER_BASE_DIR/releases/$APP_VSN/sys.config"
+    else
+        CONFIG_PATH="$RUNNER_ETC_DIR/app.config"
+    fi
 fi
 
 # Extract the target node name from node.args
@@ -57,6 +67,13 @@ if [ -z "$COOKIE_ARG" ]; then
     exit 1
 fi
 
+# Make sure CWD is set to the right dir
+cd $USE_DIR
+
+# Make sure log directory exists
+mkdir -p $USE_DIR/log
+
+
 # Add ERTS bin dir to our path
 ERTS_PATH=$RUNNER_BASE_DIR/erts-$ERTS_VSN/bin
 
@@ -65,19 +82,30 @@ NODETOOL="$ERTS_PATH/escript $ERTS_PATH/nodetool $NAME_ARG $COOKIE_ARG"
 
 # Check the first argument for instructions
 case "$1" in
-    start)
+    start|start_boot)
         # Make sure there is not already a node running
         RES=`$NODETOOL ping`
         if [ "$RES" = "pong" ]; then
             echo "Node is already running!"
             exit 1
         fi
-        shift # remove $1
+        case "$1" in
+            start)
+                shift
+                START_OPTION="console"
+                HEART_OPTION="start"
+                ;;
+            start_boot)
+                shift
+                START_OPTION="console_boot"
+                HEART_OPTION="start_boot"
+                ;;
+        esac
         RUN_PARAM=$(printf "\'%s\' " "$@")
-        HEART_COMMAND="$RUNNER_BASE_DIR/bin/$SCRIPT start $RUN_PARAM"
+        HEART_COMMAND="$RUNNER_BASE_DIR/bin/$SCRIPT $HEART_OPTION $RUN_PARAM"
         export HEART_COMMAND
         mkdir -p $PIPE_DIR
-        $ERTS_PATH/run_erl -daemon $PIPE_DIR $RUNNER_LOG_DIR "exec $RUNNER_BASE_DIR/bin/$SCRIPT console $RUN_PARAM" 2>&1
+        $ERTS_PATH/run_erl -daemon $PIPE_DIR $RUNNER_LOG_DIR "exec $RUNNER_BASE_DIR/bin/$SCRIPT $START_OPTION $RUN_PARAM" 2>&1
         ;;
 
     stop)
@@ -171,12 +199,18 @@ case "$1" in
         $ERTS_PATH/escript $RUNNER_BASE_DIR/bin/install_upgrade.escript $node_name $erlang_cookie $2
         ;;
 
-    console|console_clean)
+    console|console_clean|console_boot)
         # .boot file typically just $SCRIPT (ie, the app name)
-        # however, for debugging, sometimes start_clean.boot is useful:
+        # however, for debugging, sometimes start_clean.boot is useful.
+        # For e.g. 'setup', one may even want to name another boot script.
         case "$1" in
             console)        BOOTFILE=$SCRIPT ;;
             console_clean)  BOOTFILE=start_clean ;;
+            console_boot)
+                shift
+                BOOTFILE="$1"
+                shift
+                ;;
         esac
         # Setup beam-required vars
         ROOTDIR=$RUNNER_BASE_DIR
@@ -226,7 +260,7 @@ case "$1" in
         exec $CMD -- ${1+"$@"}
         ;;
     *)
-        echo "Usage: $SCRIPT {start|foreground|stop|restart|reboot|ping|console|console_clean|attach|upgrade}"
+        echo "Usage: $SCRIPT {start|start_boot <file>|foreground|stop|restart|reboot|ping|console|console_clean|console_boot <file>|attach|upgrade}"
         exit 1
         ;;
 esac


### PR DESCRIPTION
This patch contains two additions to simplenode.runner:

```
1. Check if vm.args exists in CWD; if so, use it. This makes it
   easier to start multiple concurrent nodes on a single machine
   from one rebar-created release (starting each node from its
   own directory, with its own copy of vm.args and e.g.
   sys.config, log directory, database directory, etc.)

2. Add the targets start_boot <file> and console_boot <file>.
   This is used to select a different boot script. The 'setup'
   application (http://github.com/esl/setup) builds a special boot
   script for installation (all apps loaded but not started,
   making it possible to run install hooks with the full code path
   in place).
```
