### PR TITLE
Add support for non-Erlang/OTP (raw) dependencies

### DIFF
--- a/inttest/t_custom_config/t_custom_config_rt.erl
+++ b/inttest/t_custom_config/t_custom_config_rt.erl
@@ -20,7 +20,7 @@ run(Dir) ->
     {ok, Missing} =
         retest:sh_expect(Ref,
                          "DEBUG: Missing deps  : \\[\\{dep,bad_name,"
-                         "boo,\"\\.\",undefined\\}\\]",
+                         "boo,\"\\.\",undefined,false\\}\\]",
                          [{capture, all, list}]),
     retest_log:log(debug, "[CAPTURED]: ~s~n", [Captured]),
     retest_log:log(debug, "[Missing]: ~s~n", [Missing]),

--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -138,7 +138,20 @@
 {deps, [application_name,
         {application_name, "1.0.*"},
         {application_name, "1.0.*",
-         {git, "git://github.com/basho/rebar.git", {branch, "master"}}}]}.
+         {git, "git://github.com/basho/rebar.git", {branch, "master"}}},
+
+%% Dependencies can be marked as 'raw'. Rebar does not require such dependencies
+%% to have a standard Erlang/OTP layout which assumes the presence of either
+%% "src/dependency_name.app.src" or "ebin/dependency_name.app" files.
+%%
+%% 'raw' dependencies can still contain 'rebar.config' and even can have the
+%% proper OTP directory layout, but they won't be compiled.
+%%
+%% Only a subset of rebar commands will be executed on the 'raw' subdirectories:
+%% get-deps, update-deps, check-deps, list-deps and delete-deps.
+        {application_name, "",
+         {git, "git://github.com/basho/rebar.git", {branch, "master"}},
+         [raw]}]}.
 
 %% == Subdirectories ==
 


### PR DESCRIPTION
It would be nice to be able to use rebar for dealing with non-Erlang dependencies
such as C libraries, build scripts, protocol definitions, etc. Here is my suggestion:

Introduce a new 'raw' option for dependency specs in rebar.config file.
For example:

``` erlang
{deps,
    {dependency_name, "1.0.*",
     {git, "<...>", {branch, "master"}},
     [raw]
    }
]}.
```

When this option is specified, rebar does not require the dependency to
have a standard Erlang/OTP layout which assumes presence of either
"src/dependency_name.app.src" or "ebin/dependency_name.app" files.
