### PR TITLE
add crypto, syntax_tools and tools to applications key as dependencies

### DIFF
--- a/ebin/rebar.app
+++ b/ebin/rebar.app
@@ -41,6 +41,7 @@
   {applications, [kernel,
                   stdlib,
                   sasl,
+                  compiler,
                   crypto,
                   syntax_tools,
                   tools]},


### PR DESCRIPTION
rebar won't function without crypto, syntax_tools and tools. while they don't strictly need to be started before rebar is run, including them in the applications key in the .app will ensure that releases that use rebar's .app file to generate dependencies will work correctly
