### PR TITLE
When generating a release rebar should expand VCS version in the top directory (git)

### DIFF
--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -432,7 +432,12 @@ vcs_vsn_cmd(git) ->
                 "(`git log -n 1 \"--pretty=format:%h\" .`) do "
                 "@git describe --always --tags %i";
         _ ->
-            "git describe --always --tags `git log -n 1 --pretty=format:%h .`"
+            case rebar_rel_utils:is_rel_dir() of
+                {true, _} ->
+                    "git describe --always --tags";
+                false ->
+                    "git describe --always --tags `git log -n 1 --pretty=format:%h .`"
+            end
     end;
 vcs_vsn_cmd(hg)  -> "hg identify -i";
 vcs_vsn_cmd(bzr) -> "bzr revno";


### PR DESCRIPTION
When a VCS tag is present in the reltool.config file, rebar tries
to expand it. However, it does so in the rel/ directory, which
(at least for git) may not reveal the latest version.

This patch tries to adress this by running "git describe --always --tags" if it's being run in the rel directory.
