### PR TITLE
new 'hostname' overlay var; dynamic .script applied to vars file

### DIFF
--- a/src/rebar_reltool.erl
+++ b/src/rebar_reltool.erl
@@ -108,7 +108,8 @@ process_overlay(ReltoolConfig) ->
     OverlayVars0 =
         dict:from_list([{erts_vsn, "erts-" ++ erlang:system_info(version)},
                         {rel_vsn, BootRelVsn},
-                        {target_dir, TargetDir}]),
+                        {target_dir, TargetDir},
+                        {hostname, net_adm:localhost()}]),
 
     %% Load up any variables specified by overlay_vars
     OverlayVars1 = overlay_vars(OverlayVars0, ReltoolConfig),
@@ -146,7 +147,7 @@ overlay_vars(Vars0, ReltoolConfig) ->
 load_vars_file(undefined) ->
     dict:new();
 load_vars_file(File) ->
-    case file:consult(File) of
+    case rebar_config:consult_file(File) of
         {ok, Terms} ->
             dict:from_list(Terms);
         {error, Reason} ->


### PR DESCRIPTION
This minor patch to rebar_reltool.erl allows to use "hostname" var to inject current hostname into configuration and other templated files. Also it extends ".script" dynamic configuration feature to vars file.
