### PR TITLE
Add color to rebar console output

### DIFF
--- a/include/color.hrl
+++ b/include/color.hrl
@@ -1,0 +1,11 @@
+-define(COLOR_BLACK,   "\e[1;30m").
+-define(COLOR_RED,     "\e[1;31m").
+-define(COLOR_GREEN,   "\e[1;32m").
+-define(COLOR_YELLOW,  "\e[1;33m").
+-define(COLOR_BLUE,    "\e[1;34m").
+-define(COLOR_MAGENTA, "\e[1;35m").
+-define(COLOR_CYAN,    "\e[1;36m").
+-define(COLOR_WHITE,   "\e[1;37m").
+
+
+-define(COLOR_OFF, "\e[0m").

--- a/include/rebar.hrl
+++ b/include/rebar.hrl
@@ -1,8 +1,16 @@
+-include("color.hrl").
+
 -define(FAIL, throw({error, failed})).
 
 -define(ABORT(Str, Args), rebar_utils:abort(Str, Args)).
 
 -define(CONSOLE(Str, Args), io:format(Str, Args)).
+-define(CONSOLE_COLOR(Color, Str, Args), ?CONSOLE(Color Str ?COLOR_OFF, Args)).
+-define(CONSOLE_RED(Str, Args), ?CONSOLE_COLOR(?COLOR_RED, Str, Args)).
+-define(CONSOLE_BLUE(Str, Args), ?CONSOLE_COLOR(?COLOR_BLUE, Str, Args)).
+-define(CONSOLE_GREEN(Str, Args), ?CONSOLE_COLOR(?COLOR_GREEN, Str, Args)).
+-define(CONSOLE_YELLOW(Str, Args), ?CONSOLE_COLOR(?COLOR_YELLOW, Str, Args)).
+-define(CONSOLE_MAGENTA(Str, Args), ?CONSOLE_COLOR(?COLOR_MAGENTA, Str, Args)).
 
 -define(DEBUG(Str, Args), rebar_log:log(debug, Str, Args)).
 -define(INFO(Str, Args), rebar_log:log(info, Str, Args)).

--- a/src/rebar_base_compiler.erl
+++ b/src/rebar_base_compiler.erl
@@ -125,7 +125,7 @@ compile_each([], _Config, _CompileFn) ->
 compile_each([Source | Rest], Config, CompileFn) ->
     case compile(Source, Config, CompileFn) of
         ok ->
-            ?CONSOLE("Compiled ~s\n", [Source]);
+            ?CONSOLE_GREEN("Compiled ~s\n", [Source]);
         skipped ->
             ?INFO("Skipped ~s\n", [Source])
     end,
@@ -152,7 +152,7 @@ compile_queue(Pids, Targets) ->
             ?FAIL;
 
         {compiled, Source} ->
-            ?CONSOLE("Compiled ~s\n", [Source]),
+            ?CONSOLE_GREEN("Compiled ~s\n", [Source]),
             compile_queue(Pids, Targets);
 
         {skipped, Source} ->

--- a/src/rebar_core.erl
+++ b/src/rebar_core.erl
@@ -108,7 +108,7 @@ process_dir(Dir, ParentConfig, Command, DirSet) ->
 
             case ShouldPrintDir of
                 true ->
-                    ?CONSOLE("==> Entering directory `~s'\n", [AbsDir]);
+                    ?CONSOLE_BLUE("==> Entering directory `~s'\n", [AbsDir]);
                 _ ->
                     ok
             end,
@@ -132,7 +132,7 @@ process_dir(Dir, ParentConfig, Command, DirSet) ->
 
             case ShouldPrintDir of
                 true ->
-                    ?CONSOLE("==> Leaving directory `~s'\n", [AbsDir]);
+                    ?CONSOLE_BLUE("==> Leaving directory `~s'\n", [AbsDir]);
                 false ->
                     ok
             end,
@@ -350,7 +350,7 @@ execute(Command, Modules, Config, ModuleFile, Env) ->
         TargetModules ->
             %% Provide some info on where we are
             Dir = rebar_utils:get_cwd(),
-            ?CONSOLE("==> ~s (~s)\n", [filename:basename(Dir), Command]),
+            ?CONSOLE_YELLOW("==> ~s (~s)\n", [filename:basename(Dir), Command]),
 
             increment_operations(),
 

--- a/src/rebar_deps.erl
+++ b/src/rebar_deps.erl
@@ -398,7 +398,7 @@ update_source(Dep) ->
     {true, AppDir} = get_deps_dir(Dep#dep.app),
     case has_vcs_dir(element(1, Dep#dep.source), AppDir) of
         true ->
-            ?CONSOLE("Updating ~p from ~p\n", [Dep#dep.app, Dep#dep.source]),
+            ?CONSOLE_MAGENTA("Updating ~p from ~p\n", [Dep#dep.app, Dep#dep.source]),
             require_source_engine(Dep#dep.source),
             update_source(AppDir, Dep#dep.source),
             Dep;


### PR DESCRIPTION
With the addition of so many extraenous "entering/leaving directory" messages
I couldn't make sense of what rebar was doing anymore.  Color makes at-a-glance
deciphering of dir changes vs. git actions vs. compiles much easier.
