### PR TITLE
Support ct_run using short name

### DIFF
--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -85,6 +85,9 @@
 %% Option to pass extra parameters when launching Common Test
 {ct_extra_params, "-boot start_sasl -s myapp"}.
 
+%% Option to use short names (i.e., -sname test) when starting ct
+{ct_use_short_names, true}.
+
 %% == Cleanup ==
 
 %% Which files to cleanup

--- a/src/rebar_ct.erl
+++ b/src/rebar_ct.erl
@@ -145,14 +145,14 @@ make_cmd(TestDir, Config) ->
               undefined ->
                   ?FMT("erl " % should we expand ERL_PATH?
                        " -noshell -pa ~s ~s"
-                       " -name test@~s"
+                       " ~s"
                        " -logdir \"~s\""
                        " -env TEST_DIR \"~s\""
                        " ~s"
                        " -s ct_run script_start -s erlang halt",
                        [CodePathString,
                         Include,
-                        net_adm:localhost(),
+                        build_name(Config),
                         LogDir,
                         filename:join(Cwd, TestDir),
                         get_extra_params(Config)]) ++
@@ -164,14 +164,14 @@ make_cmd(TestDir, Config) ->
               SpecFlags ->
                   ?FMT("erl " % should we expand ERL_PATH?
                        " -noshell -pa ~s ~s"
-                       " -name test@~s"
+                       " ~s"
                        " -logdir \"~s\""
                        " -env TEST_DIR \"~s\""
                        " ~s"
                        " -s ct_run script_start -s erlang halt",
                        [CodePathString,
                         Include,
-                        net_adm:localhost(),
+                        build_name(Config),
                         LogDir,
                         filename:join(Cwd, TestDir),
                         get_extra_params(Config)]) ++
@@ -179,6 +179,12 @@ make_cmd(TestDir, Config) ->
           end,
     RawLog = filename:join(LogDir, "raw.log"),
     {Cmd, RawLog}.
+
+build_name(Config) ->
+    case rebar_config:get_local(Config, ct_use_short_names, false) of
+        true -> "-sname test";
+        false -> " -name test@" ++ net_adm:localhost()
+    end.
 
 get_extra_params(Config) ->
     rebar_config:get_local(Config, ct_extra_params, "").


### PR DESCRIPTION
Not every system under test can be run with long names, and this makes
rebar's common_test support useless in those environments, as it
currently uses long names (test@hostname.domain) by default, without
recourse to change them.

This patch adds support for a {ct_use_short_names, boolean()} config
variable, which allows the user to specify whether short or long names
are required.
