### PR TITLE
use full paths where possible to be friendly to third party tools

### DIFF
--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -118,7 +118,7 @@ find_files(Dir, Regex) ->
 
 find_files(Dir, Regex, Recursive) ->
     filelib:fold_files(Dir, Regex, Recursive,
-                       fun(F, Acc) -> [F | Acc] end, []).
+                       fun(F, Acc) -> [filename:absname(F) | Acc] end, []).
 
 now_str() ->
     {{Year, Month, Day}, {Hour, Minute, Second}} = calendar:local_time(),


### PR DESCRIPTION
This solves an annoyance for me when using rebar with emacs and similar tools. However, this is a somewhat intrusive change that changes rebar to use full paths in most places instead of relative paths. It should also do the same for many plugins that use rebar_utils. The goal of this patch is to make the output of rebar consumable by external applications like emacs. Basically, it makes the directores output by rebar no longer dependent on where rebar is running.

The downside of this patch is that if code is _relying_ on relative paths it will break. I can't think of too many reasons why that would be the case, but I have been surprised by things in the past. I put this out for discussion if nothing else.
