### PR TITLE
Fix compile crash

### DIFF
--- a/src/rebar_base_compiler.erl
+++ b/src/rebar_base_compiler.erl
@@ -245,4 +245,7 @@ format_error(AbsSource, Extra, {{Line, Column}, Mod, Desc}) ->
     ?FMT("~s:~w:~w: ~s~s~n", [AbsSource, Line, Column, Extra, ErrorDesc]);
 format_error(AbsSource, Extra, {Line, Mod, Desc}) ->
     ErrorDesc = Mod:format_error(Desc),
-    ?FMT("~s:~w: ~s~s~n", [AbsSource, Line, Extra, ErrorDesc]).
+    ?FMT("~s:~w: ~s~s~n", [AbsSource, Line, Extra, ErrorDesc]);
+format_error(AbsSource, Extra, {Mod, Desc}) ->
+    ErrorDesc = Mod:format_error(Desc),
+    ?FMT("~s: ~s~s~n", [AbsSource, Extra, ErrorDesc]).


### PR DESCRIPTION
When file name and module name of erl don't match, rebar abort without message of error.

``` erlang
DEBUG: Worker compilation failed: [{error,
                                    {'EXIT',
                                     {function_clause,
                                      [{rebar_base_compiler,format_error,
                                        ["/home/yurin/project/test/src/test.erl",
                                         [],
                                         {compile,
                                          {module_name,test1,
                                           "test"}}]},
                                       {rebar_base_compiler,
                                        '-format_errors/3-lc$^1/1-1-',3},
                                       {rebar_base_compiler,
                                        '-format_errors/3-lc$^0/1-0-',3},
                                       {rebar_base_compiler,error_tuple,4},
                                       {rebar_base_compiler,compile,3},
                                       {rebar_base_compiler,compile_worker,
                                        3}]}}},
                                   {source,"src/test.erl"}]
ERROR: compile failed while processing /home/yurin/test: rebar_abort
```
