### PR TITLE
Eunit cover data export (#246)

### DIFF
--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -77,6 +77,9 @@
 %% Whether to print coverage report to console. Default is `false'
 {cover_print_enabled, false}.
 
+%% Whether to export coverage report to file. Default is `false'
+{cover_export_enabled, false}.
+
 %% == Common Test ==
 
 %% Override the default "test" directory in which SUITEs are located

--- a/src/rebar_eunit.erl
+++ b/src/rebar_eunit.erl
@@ -284,6 +284,14 @@ cover_analyze(Config, Modules, SrcModules) ->
     Index = filename:join([rebar_utils:get_cwd(), ?EUNIT_DIR, "index.html"]),
     ?CONSOLE("Cover analysis: ~s\n", [Index]),
 
+    %% Export coverage data, if configured
+    case rebar_config:get(Config, cover_export_enabled, false) of
+        true ->
+            cover_export_coverdata();
+        false ->
+            ok
+    end,
+
     %% Print coverage report, if configured
     case rebar_config:get(Config, cover_print_enabled, false) of
         true ->
@@ -448,6 +456,17 @@ cover_print_coverage(Coverage) ->
 
 cover_file(Module) ->
     filename:join([?EUNIT_DIR, atom_to_list(Module) ++ ".COVER.html"]).
+
+cover_export_coverdata() ->
+    ExportFile = filename:join([rebar_utils:get_cwd(), 
+                                ?EUNIT_DIR, 
+                                "eunit.coverdata"]),
+    case cover:export(ExportFile) of
+        ok ->
+            ?CONSOLE("Coverdata export: ~s~n", [ExportFile]);
+        {error,Reason} ->
+            ?ERROR("Coverdata export failed: ~p~n", [Reason])
+    end.
 
 percentage(0, 0) ->
     "not executed";


### PR DESCRIPTION
Enables users to combine cover data from several different tests or to use the coverage result in external scripts for example to show coverage in continuous build system reports.

Same as pull request #246 but in new branch. 
Caused by me trying to move commits to new clean branch...
Sorry for the inconveniences. 
