### PR TITLE
Should use ~p for printing bad term from user

### DIFF
--- a/src/rebar_reltool.erl
+++ b/src/rebar_reltool.erl
@@ -150,7 +150,7 @@ load_vars_file(File) ->
         {ok, Terms} ->
             dict:from_list(Terms);
         {error, Reason} ->
-            ?ABORT("Unable to load overlay_vars from ~s: ~p\n", [File, Reason])
+            ?ABORT("Unable to load overlay_vars from ~p: ~p\n", [File, Reason])
     end.
 
 


### PR DESCRIPTION
Since the config file doesn't necessarily contain a string/binary/atom as the filename, the error printout should use ~p to be guaranteed to be able to print (or have an earlier step that checks the type, of course, but that would be a different commit).
