### PR TITLE
fix eunit testing of apps that have no erl files

### DIFF
--- a/src/rebar_file_utils.erl
+++ b/src/rebar_file_utils.erl
@@ -57,6 +57,8 @@ rm_rf(Target) ->
     end.
 
 -spec cp_r(Sources::list(string()), Dest::file:filename()) -> ok.
+cp_r([], _Dest) ->
+    ok;
 cp_r(Sources, Dest) ->
     case os:type() of
         {unix, _} ->


### PR DESCRIPTION
'Erlang' projects that do not contain any erlang files (Joxa, LFE,
Elixir, etc) break the eunit task. It attempts to copy an empty list
of source files to the .eunit directory. This change makes copying an
empty list a simple no-op.
