### PR TITLE
Fix rebar_base_compiler:format_errors/3 for errors in include files

### DIFF
--- a/src/rebar_base_compiler.erl
+++ b/src/rebar_base_compiler.erl
@@ -235,15 +235,17 @@ maybe_report(_) ->
 report(Messages) ->
     lists:foreach(fun(Msg) -> io:format("~s", [Msg]) end, Messages).
 
-format_errors(Config, Source, Extra, Errors) ->
-    AbsSource = case rebar_utils:processing_base_dir(Config) of
-                    true ->
-                        Source;
-                    false ->
-                        filename:absname(Source)
-                end,
-    [[format_error(AbsSource, Extra, Desc) || Desc <- Descs]
-     || {_, Descs} <- Errors].
+format_errors(Config, _MainSource, Extra, Errors) ->
+    [begin
+         AbsSource = case rebar_utils:processing_base_dir(Config) of
+                         true ->
+                             Source;
+                         false ->
+                             filename:absname(Source)
+                     end,
+         [format_error(AbsSource, Extra, Desc) || Desc <- Descs]
+     end
+     || {Source, Descs} <- Errors].
 
 format_error(AbsSource, Extra, {{Line, Column}, Mod, Desc}) ->
     ErrorDesc = Mod:format_error(Desc),


### PR DESCRIPTION
Handle the case where the error didn't occur in the file being
compiled.  That is, instead of:

```
/path/to/foo.erl:9: type foo() already defined
```

print something like:

```
In file included from /path/to/foo.erl:
/path/to/bar.hrl:9: type foo() already defined
```
