### PR TITLE
Changing escriptized rebar permissions to a+x

### DIFF
--- a/src/rebar_escripter.erl
+++ b/src/rebar_escripter.erl
@@ -84,7 +84,7 @@ escriptize(Config, AppFile) ->
 
     %% Finally, update executable perms for our script
     {ok, #file_info{mode = Mode}} = file:read_file_info(Filename),
-    ok = file:change_mode(Filename, Mode bor 8#00100),
+    ok = file:change_mode(Filename, Mode bor 8#00111),
     ok.
 
 clean(Config, AppFile) ->


### PR DESCRIPTION
By default, executables in paths such as /bin and /usr/local/bin
have the mode saying they can be executed by all.

The current version of rebar only has the user able to execute it,
which creates problems when copied directly in repositorie and
requiring other programs to interact with them.

This change makes rebar follow the standard of linuxes and unixes
by setting the permission flag to a+x, allowing users, the group
and others to execute it.
