### PR TITLE
Removal of two lines that do nothing

### DIFF
--- a/src/rebar_rel_utils.erl
+++ b/src/rebar_rel_utils.erl
@@ -107,8 +107,7 @@ get_rel_apps(Name, Path) ->
 get_rel_file_path(Name, Path) ->
     [RelFile] = filelib:wildcard(filename:join([Path, "releases", "*",
                                                 Name ++ ".rel"])),
-    [BinDir|_] = re:replace(RelFile, Name ++ "\\.rel", ""),
-    filename:join([binary_to_list(BinDir), Name ++ ".rel"]).
+    RelFile.
 
 %% Get the previous release path from a global variable
 get_previous_release_path() ->


### PR DESCRIPTION
As far as I can tell, these two lines of deconstructing and recontructing a path do nothing.

(Aside: the line above uses a "*" in a situation where the release name should be known (from either RELEASES or from command line option).  I'm not too happy about this, but don't have a patch for the time being.  We'll see if we go down this path for release handling or not, and if so I'll send a patch upstream.)
