### PR TITLE
More appropriate method to check Reltools version.

### DIFF
--- a/src/rebar_reltool.erl
+++ b/src/rebar_reltool.erl
@@ -89,7 +89,6 @@ check_vsn() ->
             _ ->
                 ""
         end,
-    io:fwrite("ReltoolVsn is = ~p~n", [ReltoolVsn]),
     case ReltoolVsn < "0.5.2" of
         true ->
             ?ABORT("Reltool support requires at least reltool-0.5.2; "


### PR DESCRIPTION
If running e.g. rebar generate using an OTP development build,
rebar will complain that reltool has the version "", which is
less than the required "0.5.2". This is because rebar_reltool
simply checks the path returned by code:which(reltool), which
doesn't yield version information if used in a development build.

This patch substitutes a more robust method (load reltool and
fetch the info from application:loaded_applications().

As it happens, this will not be enough to make things work,
but now Reltool will explain that it cannot generate a spec
from a system that is not installed, giving a better hint
as to what needs to be done.
