### PR TITLE
Add missing 'defines' to global config

### DIFF
--- a/src/rebar_port_compiler.erl
+++ b/src/rebar_port_compiler.erl
@@ -156,15 +156,15 @@ setup_env(Config, ExtraEnv) ->
     DefaultEnv  = filter_env(default_env(), []),
     RawPortEnv = rebar_config:get_list(Config, port_env, []),
     PortEnv = filter_env(RawPortEnv, []),
-    GlobalDefines = global_defines(Config),
-    OverrideEnv = GlobalDefines ++ PortEnv ++ filter_env(ExtraEnv, []),
+    Defines = get_defines(Config),
+    OverrideEnv = Defines ++ PortEnv ++ filter_env(ExtraEnv, []),
     RawEnv = apply_defaults(os_env(), DefaultEnv) ++ OverrideEnv,
     expand_vars_loop(merge_each_var(RawEnv, [])).
 
-global_defines(Config) ->
-    Defines = rebar_config:get_global(Config, defines, []),
-    Flags = string:join(["-D" ++ D || D <- Defines], " "),
-    [{"ERL_CFLAGS", "$ERL_CFLAGS " ++ Flags}].
+get_defines(Config) ->
+    RawDefines = rebar_config:get_xconf(Config, defines, []),
+    Defines = string:join(["-D" ++ D || D <- RawDefines], " "),
+    [{"ERL_CFLAGS", "$ERL_CFLAGS " ++ Defines}].
 
 replace_extension(File, NewExt) ->
     OldExt = filename:extension(File),

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -291,9 +291,9 @@ delayed_halt(Code) ->
 -spec erl_opts(rebar_config:config()) -> list().
 erl_opts(Config) ->
     RawErlOpts = filter_defines(rebar_config:get(Config, erl_opts, []), []),
-    GlobalDefines = [{d, list_to_atom(D)} ||
-                        D <- rebar_config:get_global(Config, defines, [])],
-    Opts = GlobalDefines ++ RawErlOpts,
+    Defines = [{d, list_to_atom(D)} ||
+                        D <- rebar_config:get_xconf(Config, defines, [])],
+    Opts = Defines ++ RawErlOpts,
     case proplists:is_defined(no_debug_info, Opts) of
         true ->
             [O || O <- Opts, O =/= no_debug_info];


### PR DESCRIPTION
-D <defines> passed to rebar on the command line via getopt were ignored by the compile and test-compile commands.  This behaviour looks like a regression.

  $ ./rebar -h
  Usage: rebar [-h] [-c] [-v <verbose>] [-V] [-f] [-D <defines>] [-j <jobs>] [-C <config>] [-p] [-k] [var=value,...] <command,...>

  -h, --help        Show the program options
  -c, --commands    Show available commands
  -v, --verbose     Verbosity level (-v, -vv, -vvv, --verbose 3). Default: 0
  -V, --version     Show version information
  -f, --force       Force
  -D            Define compiler macro
  -j, --jobs        Number of concurrent workers a command may use. Default: 3
  -C, --config      Rebar config file to use
  -p, --profile     Profile this run of rebar
  -k, --keep-going  Keep running after a command fails
  var=value     rebar global variables (e.g. force=1)
  command       Command to run (e.g. compile)
