### PR TITLE
Add ct_log_dir option, skip test dir with no SUITE

### DIFF
--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -83,6 +83,9 @@
 %% Override the default "test" directory in which SUITEs are located
 {ct_dir, "itest"}.
 
+%% Override the default "logs" directory in which SUITEs are logged
+{ct_log_dir, "test/logs"}.
+
 %% Option to pass extra parameters when launching Common Test
 {ct_extra_params, "-boot start_sasl -s myapp"}.
 


### PR DESCRIPTION
When rebar ct executes with its default common test directory of "test",
it will generate a hardcoded "logs" directory in every application with
a test directory present, causing an overlap with eunit's test framework
so even test directories with only eunit tests will be processed by ct.

---

References #175
The additional check displays as follows:

rebar ct -v 
==> whatever (ct)
WARN: test directory present, but no common_test SUITES - skipping
