### PR TITLE
Quote paths in Windows runner script

### DIFF
--- a/priv/templates/simplenode.windows.start_erl.cmd
+++ b/priv/templates/simplenode.windows.start_erl.cmd
@@ -6,30 +6,31 @@
 @for /F "delims=++ tokens=1,2,3" %%I in (%args%) do @(
     @set erl_args=%%I
     @call :set_trim node_name %%J
-    @call :set_trim node_root %%K
+    @rem Trim spaces from the left of %%K (node_root), which may have spaces inside
+    @for /f "tokens=* delims= " %%a in ("%%K") do @set node_root=%%a
 )
 
 @set releases_dir=%node_root%\releases
 
 @rem parse ERTS version and release version from start_erl.dat
-@for /F "tokens=1,2" %%I in (%releases_dir%\start_erl.data) do @(
+@for /F "usebackq tokens=1,2" %%I in ("%releases_dir%\start_erl.data") do @(
     @call :set_trim erts_version %%I
     @call :set_trim release_version %%J
 )
 
-@set erl_exe=%node_root%\erts-%erts_version%\bin\erl.exe
-@set boot_file=%releases_dir%\%release_version%\%node_name%
+@set erl_exe="%node_root%\erts-%erts_version%\bin\erl.exe"
+@set boot_file="%releases_dir%\%release_version%\%node_name%"
 
-@if exist %releases_dir%\%release_version%\sys.config (
-    @set app_config=%releases_dir%\%release_version%\sys.config
+@if exist "%releases_dir%\%release_version%\sys.config" (
+    @set app_config="%releases_dir%\%release_version%\sys.config"
 ) else (
-    @set app_config=%node_root%\etc\app.config
+    @set app_config="%node_root%\etc\app.config"
 )
 
-@if exist %releases_dir%\%release_version%\vm.args (
-    @set vm_args=%releases_dir%\%release_version%\vm.args
+@if exist "%releases_dir%\%release_version%\vm.args" (
+    @set vm_args="%releases_dir%\%release_version%\vm.args"
 ) else (
-    @set vm_args=%node_root%\etc\vm.args
+    @set vm_args="%node_root%\etc\vm.args"
 )
 
 @%erl_exe% %erl_args% -boot %boot_file% -config %app_config% -args_file %vm_args%


### PR DESCRIPTION
This allows the node to run in paths which include special characters,
for example 'C:\Program Files (x86)\Product Name'
