### PR TITLE
`rebar compile` should not change files

### DIFF
--- a/src/rebar_file_utils.erl
+++ b/src/rebar_file_utils.erl
@@ -112,10 +112,9 @@ delete_each([File | Rest]) ->
             ?FAIL
     end.
 
--spec write_file_if_contents_differ(Filename, Bytes) -> ok | {error, Reason} when
-    Filename :: file:name(),
-    Bytes :: iodata(),
-    Reason :: file:posix() | badarg | terminated | system_limit.
+-type file_write_reason() :: file:posix() | badarg | terminated | system_limit.
+-spec write_file_if_contents_differ(Filename::file:name(), Bytes::iodata()) ->
+                                             ok | {error, file_write_reason()}.
 write_file_if_contents_differ(Filename, Bytes) ->
     ToWrite = iolist_to_binary(Bytes),
     case file:read_file(Filename) of

--- a/src/rebar_file_utils.erl
+++ b/src/rebar_file_utils.erl
@@ -29,7 +29,8 @@
 -export([rm_rf/1,
          cp_r/2,
          mv/2,
-         delete_each/1]).
+         delete_each/1,
+         write_file_if_contents_differ/2]).
 
 -include("rebar.hrl").
 
@@ -109,6 +110,18 @@ delete_each([File | Rest]) ->
         {error, Reason} ->
             ?ERROR("Failed to delete file ~s: ~p\n", [File, Reason]),
             ?FAIL
+    end.
+
+-spec write_file_if_contents_differ(Filename, Bytes) -> ok | {error, Reason} when
+    Filename :: file:name(),
+    Bytes :: iodata(),
+    Reason :: file:posix() | badarg | terminated | system_limit.
+write_file_if_contents_differ(Filename, Bytes) ->
+    ToWrite = iolist_to_binary(Bytes),
+    case file:read_file(Filename) of
+        {ok, ToWrite} -> ok;
+        {ok,  _}    -> file:write_file(Filename, ToWrite);
+        {error,  _} -> file:write_file(Filename, ToWrite)
     end.
 
 %% ===================================================================

--- a/src/rebar_otp_app.erl
+++ b/src/rebar_otp_app.erl
@@ -106,7 +106,7 @@ preprocess(Config, AppSrcFile) ->
 
             %% Setup file .app filename and write new contents
             AppFile = rebar_app_utils:app_src_to_app(AppSrcFile),
-            ok = file:write_file(AppFile, Spec),
+            ok = rebar_file_utils:write_file_if_contents_differ(AppFile, Spec),
 
             %% Make certain that the ebin/ directory is available
             %% on the code path


### PR DESCRIPTION
At the moment `rebar compile` always changes the .app file even if its contents do not change. In some instances this is undesirable, as it forces recompiling unnecessary dependencies. This patch proposes to fix it by comparing the existing .app file with the contents rebar is about to write. If they match, rebar touches nothing on the file system.
