### PR TITLE
Add experimental tests= filter without eunit suites

### DIFF
--- a/src/rebar.erl
+++ b/src/rebar.erl
@@ -300,6 +300,11 @@ generate-appups   previous_release=path  Generate appup files
 eunit       [suites=foo]             Run eunit tests [foo.erl and test/foo_tests.erl]
             [suites=foo] [tests=bar] Run specific eunit tests [first test name starting
                                      with 'bar' in foo.erl and test/foo_tests.erl]
+            [tests=bar]              For every existing suite, run the first test whose
+                                     name starts with bar and, if no such test exists,
+                                     run the test whose name starts with bar in
+                                     the suite's _tests module
+
 ct          [suites=] [case=]        Run common_test suites
 
 qc                                   Test QuickCheck properties

--- a/test/rebar_eunit_tests.erl
+++ b/test/rebar_eunit_tests.erl
@@ -138,7 +138,7 @@ eunit_with_suites_and_tests_test_() ->
                {"Selected suite tests are run once",
                 ?_assert(string:str(RebarOut, "All 3 tests passed") =/= 0)}]
       end},
-     {"Ensure EUnit runs specific test in _tests suites",
+     {"Ensure EUnit runs specific test in a _tests suite",
       setup,
       fun() ->
               setup_project_with_multiple_modules(),
@@ -155,6 +155,24 @@ eunit_with_suites_and_tests_test_() ->
 
                {"Selected suite tests is run once",
                 ?_assert(string:str(RebarOut, "Test passed") =/= 0)}]
+      end},
+     {"Ensure EUnit runs a specific test without a specified suite",
+      setup,
+      fun() ->
+              setup_project_with_multiple_modules(),
+              rebar("-v eunit tests=myprivate")
+      end,
+      fun teardown/1,
+      fun(RebarOut) ->
+              [{"Only selected suite tests are found and run",
+                [?_assert(string:str(RebarOut,
+                                     "myapp_mymod:myprivate_test/0") =/= 0),
+                 ?_assert(string:str(RebarOut,
+                                     "myapp_mymod2:myprivate2_test/0")
+                          =/= 0)]},
+
+               {"Selected suite tests is run once",
+                ?_assert(string:str(RebarOut, "All 2 tests passed") =/= 0)}]
       end}].
 
 cover_test_() ->


### PR DESCRIPTION
Now the experimental option `tests=` can be used without the need to specify `suites=`. The behaviour is the same as if all suites were specified.

So if `rebar eunit tests=foo` is run, for every suite:
- run the first test whose name starts with `foo`
- if no such test exists, look into the suite's `_tests` module for a test whose name starts with `foo` and if found, run it.
