### PR TITLE
Fix tests= option not running generator tests

### DIFF
--- a/src/rebar_eunit.erl
+++ b/src/rebar_eunit.erl
@@ -211,8 +211,17 @@ build_tests(Config, SuitesModules) ->
                 RawTests ->
                     ?CONSOLE("    Running test function(s):~n", []),
                     F = fun({M, F2}, Acc) ->
-                                ?CONSOLE("      ~p:~p/0~n", [M, F2]),
-                                [eunit_test:function_wrapper(M, F2)|Acc]
+                            ?CONSOLE("      ~p:~p/0~n", [M, F2]),
+                            FNameStr = atom_to_list(F2),
+                            NewFunction = case re:run(FNameStr, "_test_") =/= nomatch of
+                                true ->
+                                    %% Generator
+                                    {generator, eunit_test:function_wrapper(M, F2)};
+                                _ ->
+                                    %% Normal test
+                                    eunit_test:function_wrapper(M, F2)
+                            end,
+                            [NewFunction|Acc]
                         end,
                     lists:foldl(F, [], RawTests)
             end

--- a/test/rebar_eunit_tests.erl
+++ b/test/rebar_eunit_tests.erl
@@ -118,6 +118,24 @@ eunit_with_suites_and_tests_test_() ->
                {"Selected suite tests is run once",
                 ?_assert(string:str(RebarOut, "Test passed") =/= 0)}]
       end},
+     {"Ensure EUnit runs a specific generator test defined in a selected suite",
+      setup, fun() ->
+                     setup_project_with_multiple_modules(),
+                     rebar("-v eunit suites=myapp_mymod3 tests=mygenerator")
+             end,
+      fun teardown/1,
+      fun(RebarOut) ->
+              [{"Selected suite's generator test is found and run",
+                ?_assert(string:str(RebarOut,
+                                    "myapp_mymod3:mygenerator_test_/0") =/= 0)},
+
+                {"Selected suite's generator test raises an error",
+                ?_assert(string:str(RebarOut,
+                                    "assertEqual_failed") =/= 0)},
+
+               {"Selected suite tests is run once",
+                ?_assert(string:str(RebarOut, "Failed: 1.") =/= 0)}]
+      end},
      {"Ensure EUnit runs specific tests defined in selected suites",
       setup, fun() ->
                      setup_project_with_multiple_modules(),
@@ -271,6 +289,13 @@ basic_setup_test_() ->
          "myfunc2_test() -> ?assertMatch(ok, myapp_mymod2:myfunc2()).\n",
          "common_name_test() -> ?assert(true).\n"]).
 
+-define(myapp_mymod3,
+        ["-module(myapp_mymod3).\n",
+         "-export([myfunc3/0]).\n",
+         "-include_lib(\"eunit/include/eunit.hrl\").\n",
+         "myfunc3() -> ok.\n",
+         "mygenerator_test_() -> [?_assertEqual(true, false)].\n"]).
+
 -define(mysuite,
         ["-module(mysuite).\n",
          "-export([all_test_/0]).\n",
@@ -302,7 +327,8 @@ setup_basic_project() ->
 setup_project_with_multiple_modules() ->
     setup_basic_project(),
     ok = file:write_file("test/myapp_mymod2_tests.erl", ?myapp_mymod2_tests),
-    ok = file:write_file("src/myapp_mymod2.erl", ?myapp_mymod2).
+    ok = file:write_file("src/myapp_mymod2.erl", ?myapp_mymod2),
+    ok = file:write_file("src/myapp_mymod3.erl", ?myapp_mymod3).
 
 setup_cover_project() ->
     setup_basic_project(),


### PR DESCRIPTION
This patch fixes generator tests not being run. Before this patch, any failing generator test would result as passing, probably due to the function wrapper not handling them as test functions.
