### PR TITLE
Add other deps to library path when running xref

### DIFF
--- a/src/rebar_xref.erl
+++ b/src/rebar_xref.erl
@@ -44,7 +44,7 @@
 xref(Config, _) ->
     %% Spin up xref
     {ok, _} = xref:start(xref),
-    ok = xref:set_library_path(xref, code_path()),
+    ok = xref:set_library_path(xref, code_path(Config)),
 
     xref:set_default(xref, [{warnings,
                              rebar_config:get(Config, xref_warnings, false)},
@@ -132,9 +132,12 @@ check_query({Query, Value}) ->
             true
     end.
 
-code_path() ->
-    [P || P <- code:get_path(),
-          filelib:is_dir(P)] ++ [filename:join(rebar_utils:get_cwd(), "ebin")].
+code_path(Config) ->
+    BaseDir = rebar_config:get_xconf(Config, base_dir),
+    [P || P <- code:get_path() ++
+              [filename:join(BaseDir, filename:join(SubDir, "ebin"))
+               || SubDir <- rebar_config:get(Config, sub_dirs, [])],
+          filelib:is_dir(P)].
 
 %%
 %% Ignore behaviour functions, and explicitly marked functions


### PR DESCRIPTION
For those of us who do their sub_dirs as

```
{sub_dirs, ["apps/app1",
                "apps/app2"...]}.
```

the other apps are not available in xrefs library path so calls between applications will always be seen as calls to undefined functions.

This fixes that problem.

(The proper and correct solution to how to run xref is of course to use a filtered code path which only contains applications which are (recursively) dependencies of the app that is currently checked.  This is a bit bigger, and not part of the current pull request.)
