### PR TITLE
Restore ability to specify deps_dir on the command line

### DIFF
--- a/src/rebar_deps.erl
+++ b/src/rebar_deps.erl
@@ -185,7 +185,8 @@ setup_env(Config) ->
 %% Sets a default if root config has no deps_dir set
 set_shared_deps_dir(Config, []) ->
     rebar_config:set_xconf(Config, deps_dir,
-                           rebar_config:get_local(Config, deps_dir, "deps"));
+                           rebar_config:get_local(Config, deps_dir, 
+                            rebar_config:get_global(Config, deps_dir, "deps")));
 set_shared_deps_dir(Config, _DepsDir) ->
     Config.
 


### PR DESCRIPTION
It was previously possible to run `rebar compile deps_dir=/path/to/deps`,
as of 70d27c5720331076f52e4fd7bcd1dc8045c8c86a, it was nixed.

This commit fixes this problem.
