### PR TITLE
Add fossil scm to recognized source control systems

### DIFF
--- a/src/rebar_deps.erl
+++ b/src/rebar_deps.erl
@@ -410,7 +410,19 @@ download_source(AppDir, {svn, Url, Rev}) ->
                    [{cd, filename:dirname(AppDir)}]);
 download_source(AppDir, {rsync, Url}) ->
     ok = filelib:ensure_dir(AppDir),
-    rebar_utils:sh(?FMT("rsync -az --delete ~s/ ~s", [Url, AppDir]), []).
+    rebar_utils:sh(?FMT("rsync -az --delete ~s/ ~s", [Url, AppDir]), []);
+download_source(AppDir, {fossil, Url}) ->
+    download_source(AppDir, {fossil, Url, ""});
+download_source(AppDir, {fossil, Url, latest}) ->
+    download_source(AppDir, {fossil, Url, ""});
+download_source(AppDir, {fossil, Url, Version}) ->
+    Repository = filename:join(AppDir, filename:basename(AppDir) ++ ".fossil"),
+    ok = filelib:ensure_dir(Repository),
+    ok = file:set_cwd(AppDir),
+    rebar_utils:sh(?FMT("fossil clone ~s ~s", [Url, Repository]),
+                   [{cd, AppDir}]),
+    rebar_utils:sh(?FMT("fossil open ~s ~s --nested", [Repository, Version]),
+                   []).
 
 update_source(Config, Dep) ->
     %% It's possible when updating a source, that a given dep does not have a
@@ -453,7 +465,16 @@ update_source1(AppDir, {hg, _Url, Rev}) ->
 update_source1(AppDir, {bzr, _Url, Rev}) ->
     rebar_utils:sh(?FMT("bzr update -r ~s", [Rev]), [{cd, AppDir}]);
 update_source1(AppDir, {rsync, Url}) ->
-    rebar_utils:sh(?FMT("rsync -az --delete ~s/ ~s",[Url,AppDir]),[]).
+    rebar_utils:sh(?FMT("rsync -az --delete ~s/ ~s",[Url,AppDir]),[]);
+update_source1(AppDir, {fossil, Url}) ->
+    update_source1(AppDir, {fossil, Url, ""});
+update_source1(AppDir, {fossil, Url, latest}) ->
+    update_source1(AppDir, {fossil, Url, ""});
+update_source1(AppDir, {fossil, _Url, Version}) ->
+    ok = file:set_cwd(AppDir),
+    rebar_utils:sh("fossil pull", [{cd, AppDir}]),
+    rebar_utils:sh(?FMT("fossil update ~s", [Version]), []).
+
 
 %% ===================================================================
 %% Source helper functions
@@ -464,7 +485,7 @@ source_engine_avail(Source) ->
     source_engine_avail(Name, Source).
 
 source_engine_avail(Name, Source)
-  when Name == hg; Name == git; Name == svn; Name == bzr; Name == rsync ->
+  when Name == hg; Name == git; Name == svn; Name == bzr; Name == rsync; Name == fossil ->
     case vcs_client_vsn(Name) >= required_vcs_client_vsn(Name) of
         true ->
             true;
@@ -485,11 +506,12 @@ vcs_client_vsn(Path, VsnArg, VsnRegex) ->
             false
     end.
 
-required_vcs_client_vsn(hg)    -> {1, 1};
-required_vcs_client_vsn(git)   -> {1, 5};
-required_vcs_client_vsn(bzr)   -> {2, 0};
-required_vcs_client_vsn(svn)   -> {1, 6};
-required_vcs_client_vsn(rsync) -> {2, 0}.
+required_vcs_client_vsn(hg)     -> {1, 1};
+required_vcs_client_vsn(git)    -> {1, 5};
+required_vcs_client_vsn(bzr)    -> {2, 0};
+required_vcs_client_vsn(svn)    -> {1, 6};
+required_vcs_client_vsn(rsync)  -> {2, 0};
+required_vcs_client_vsn(fossil) -> {1, 0}.
 
 vcs_client_vsn(hg) ->
     vcs_client_vsn(rebar_utils:find_executable("hg"), " --version",
@@ -505,7 +527,10 @@ vcs_client_vsn(svn) ->
                    "svn, version (\\d+).(\\d+)");
 vcs_client_vsn(rsync) ->
     vcs_client_vsn(rebar_utils:find_executable("rsync"), " --version",
-                   "rsync  version (\\d+).(\\d+)").
+                   "rsync  version (\\d+).(\\d+)");
+vcs_client_vsn(fossil) ->
+    vcs_client_vsn(rebar_utils:find_executable("fossil"), " version",
+                   "version (\\d+).(\\d+)").
 
 has_vcs_dir(git, Dir) ->
     filelib:is_dir(filename:join(Dir, ".git"));

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -486,9 +486,10 @@ vcs_vsn_cmd(git) ->
         _ ->
             "git describe --always --tags `git log -n 1 --pretty=format:%h .`"
     end;
-vcs_vsn_cmd(hg)  -> "hg identify -i";
-vcs_vsn_cmd(bzr) -> "bzr revno";
-vcs_vsn_cmd(svn) -> "svnversion";
+vcs_vsn_cmd(hg)     -> "hg identify -i";
+vcs_vsn_cmd(bzr)    -> "bzr revno";
+vcs_vsn_cmd(svn)    -> "svnversion";
+vcs_vsn_cmd(fossil) -> "fossil info";
 vcs_vsn_cmd({cmd, _Cmd}=Custom) -> Custom;
 vcs_vsn_cmd(Version) -> {unknown, Version}.
 


### PR DESCRIPTION
As fossil has some advantages for my development (local development, single executable, easy to setup, repository easily transferable between Linux and Windows, etc.) I've added it to the recognized scm's of rebar.

Please comment on it, or include it in the official rebar distribution.

Best regards,

Martin Schut
