### PR TITLE
Added retry logic to error handling for shelled out commands

### DIFF
--- a/include/rebar.hrl
+++ b/include/rebar.hrl
@@ -12,3 +12,5 @@
 -define(ERROR(Str, Args), rebar_log:log(error, Str, Args)).
 
 -define(FMT(Str, Args), lists:flatten(io_lib:format(Str, Args))).
+
+-define(DEFAULT_RETRIES, 0).

--- a/src/rebar_deps.erl
+++ b/src/rebar_deps.erl
@@ -376,54 +376,73 @@ use_source(Config, Dep, Count) ->
     end.
 
 download_source(AppDir, {hg, Url, Rev}) ->
+    download_source(AppDir, {hg, Url, Rev, {retries, ?DEFAULT_RETRIES}});
+download_source(AppDir, {hg, Url, Rev, {retries, Retries}}) ->
     ok = filelib:ensure_dir(AppDir),
     rebar_utils:sh(?FMT("hg clone -U ~s ~s", [Url, filename:basename(AppDir)]),
-                   [{cd, filename:dirname(AppDir)}]),
+                   [{cd, filename:dirname(AppDir)},
+                    {retry_on_error, retry_handler(AppDir, Retries)}]),
     rebar_utils:sh(?FMT("hg update ~s", [Rev]), [{cd, AppDir}]);
 download_source(AppDir, {git, Url}) ->
-    download_source(AppDir, {git, Url, {branch, "HEAD"}});
+    download_source(AppDir, {git, Url, {branch, "HEAD"}, {retries, ?DEFAULT_RETRIES}});
 download_source(AppDir, {git, Url, ""}) ->
-    download_source(AppDir, {git, Url, {branch, "HEAD"}});
+    download_source(AppDir, {git, Url, {branch, "HEAD"}, {retries, ?DEFAULT_RETRIES}});
 download_source(AppDir, {git, Url, {branch, Branch}}) ->
-    ok = filelib:ensure_dir(AppDir),
-    rebar_utils:sh(?FMT("git clone -n ~s ~s", [Url, filename:basename(AppDir)]),
-                   [{cd, filename:dirname(AppDir)},
-                    {retry_on_error, cleanup_retry_clone(AppDir)}]),
-    rebar_utils:sh(?FMT("git checkout -q origin/~s", [Branch]), [{cd, AppDir}]);
+    download_source(AppDir, {git, Url, {branch, Branch}, {retries, ?DEFAULT_RETRIES}});
 download_source(AppDir, {git, Url, {tag, Tag}}) ->
-    ok = filelib:ensure_dir(AppDir),
-    rebar_utils:sh(?FMT("git clone -n ~s ~s", [Url, filename:basename(AppDir)]),
-                   [{cd, filename:dirname(AppDir)},
-                    {retry_on_error, cleanup_retry_clone(AppDir)}]),
-    rebar_utils:sh(?FMT("git checkout -q ~s", [Tag]), [{cd, AppDir}]);
+    download_source(AppDir, {git, Url, {tag, Tag}, {retries, ?DEFAULT_RETRIES}});
 download_source(AppDir, {git, Url, Rev}) ->
+    download_source(AppDir, {git, Url, Rev, {retries, ?DEFAULT_RETRIES}});
+download_source(AppDir, {svn, Url, Rev}) ->
+    download_source(AppDir, {svn, Url, Rev, {retries, ?DEFAULT_RETRIES}});
+download_source(AppDir, {git, Url, {branch, Branch}, {retries, Retries}}) ->
     ok = filelib:ensure_dir(AppDir),
     rebar_utils:sh(?FMT("git clone -n ~s ~s", [Url, filename:basename(AppDir)]),
                    [{cd, filename:dirname(AppDir)},
-                    {retry_on_error, cleanup_retry_clone(AppDir)}]),
+                    {retry_on_error, retry_handler(AppDir, Retries)}]),
+    rebar_utils:sh(?FMT("git checkout -q origin/~s", [Branch]), [{cd, AppDir}]);
+download_source(AppDir, {git, Url, {tag, Tag}, {retries, Retries}}) ->
+    ok = filelib:ensure_dir(AppDir),
+    rebar_utils:sh(?FMT("git clone -n ~s ~s", [Url, filename:basename(AppDir)]),
+                   [{cd, filename:dirname(AppDir)},
+                    {retry_on_error, retry_handler(AppDir, Retries)}]),
+    rebar_utils:sh(?FMT("git checkout -q ~s", [Tag]), [{cd, AppDir}]);
+download_source(AppDir, {git, Url, Rev, {retries, Retries}}) ->
+    ok = filelib:ensure_dir(AppDir),
+    rebar_utils:sh(?FMT("git clone -n ~s ~s", [Url, filename:basename(AppDir)]),
+                   [{cd, filename:dirname(AppDir)},
+                    {retry_on_error, retry_handler(AppDir, Retries)}]),
     rebar_utils:sh(?FMT("git checkout -q ~s", [Rev]), [{cd, AppDir}]);
-download_source(AppDir, {bzr, Url, Rev}) ->
+download_source(AppDir, {bzr, Url, Rev, {retries, Retries}}) ->
     ok = filelib:ensure_dir(AppDir),
     rebar_utils:sh(?FMT("bzr branch -r ~s ~s ~s",
                         [Rev, Url, filename:basename(AppDir)]),
-                   [{cd, filename:dirname(AppDir)}]);
-download_source(AppDir, {svn, Url, Rev}) ->
+                   [{cd, filename:dirname(AppDir)},
+                    {retry_on_error, retry_handler(AppDir, Retries)}]);
+download_source(AppDir, {svn, Url, Rev, {retries, Retries}}) ->
     ok = filelib:ensure_dir(AppDir),
     rebar_utils:sh(?FMT("svn checkout -r ~s ~s ~s",
                         [Rev, Url, filename:basename(AppDir)]),
-                   [{cd, filename:dirname(AppDir)}]);
+                   [{cd, filename:dirname(AppDir)},
+                    {retry_on_error, retry_handler(AppDir, Retries)}]);
 download_source(AppDir, {rsync, Url}) ->
+    download_source(AppDir, {rsync, Url, {retries, ?DEFAULT_RETRIES}});
+download_source(AppDir, {rsync, Url, {retries, Retries}}) ->
     ok = filelib:ensure_dir(AppDir),
-    rebar_utils:sh(?FMT("rsync -az --delete ~s/ ~s", [Url, AppDir]), []).
+    rebar_utils:sh(?FMT("rsync -az --delete ~s/ ~s", [Url, AppDir]),
+                   [{retry_on_error, retry_handler(AppDir, Retries)}]).
 
-cleanup_retry_clone(AppDir) ->
-    fun(_Command, _Error, 4) ->
-            false;
-       (_Command, _Error, Count) ->
-            Wait = 250 * Count,
-            timer:sleep(Wait),
-            rebar_file_utils:rm_rf(AppDir),
-            true end.
+retry_handler(AppDir, Threshold) ->
+    fun(_Command, _Error, Retries) ->
+            if
+                Retries >= Threshold ->
+                    false;
+                true ->
+                    Wait = 250 * Retries,
+                    timer:sleep(Wait),
+                    rebar_file_utils:rm_rf(AppDir),
+                    true
+            end end.
 
 update_source(Config, Dep) ->
     %% It's possible when updating a source, that a given dep does not have a

--- a/src/rebar_deps.erl
+++ b/src/rebar_deps.erl
@@ -417,22 +417,12 @@ download_source(AppDir, {rsync, Url}) ->
     rebar_utils:sh(?FMT("rsync -az --delete ~s/ ~s", [Url, AppDir]), []).
 
 cleanup_retry_clone(AppDir) ->
-    Cleanup = case os:type() of
-                  {win32,nt} ->
-                      "rd /q /s " ++ AppDir;
-                  _ ->
-                      "rm -rf " ++ AppDir
-              end,
-    fun(Command, {Rc, Output}, 4) ->
-            io:format("~s failed with error: ~w and output:~n~s~n",
-                      [Command, Rc, Output]),
+    fun(_Command, _Error, 4) ->
             false;
-       (Command, {Rc, Output}, Count) ->
+       (_Command, _Error, Count) ->
             Wait = 250 * Count,
-            io:format("~s failed with error: ~w and output:~n~s~nRetrying in ~wms~n",
-                      [Command, Rc, Output, Wait]),
             timer:sleep(Wait),
-            rebar_utils:sh(Cleanup, []),
+            rebar_file_utils:rm_rf(AppDir),
             true end.
 
 update_source(Config, Dep) ->


### PR DESCRIPTION
This is an attempt to work around recent github flakiness. Our automated
rebar builds have been failing quite often due to clones of deps erroring
when github has a flaky episode. We considered hosting our own repos
to workaround the problem but decided teaching rebar to retry on errors
was less work and generally more useful.

I added the option {error_handler, {retry, Fun}} to the list options
rebar_utils.sh/2 understands. The retry function is called with the
command and error, as rebar does with existing error handlers, and
a third argument representing the number of retries attempted. The
retry function must return a boolean indicating whether or not the
failing operation should be retried. 

The git cloning logic was then modified to use the retry handler.
Failing clone operations will be retried for a hardcoded maximum of
3 times. rebar will sleep for an increasing interval before each retry:
250ms, 500ms, 750ms. The dep directory containing the failed clone
is deleted before each retry, too.
