### PR TITLE
Fix return value of rebar_overlay

### DIFF
--- a/src/rebar_reltool.erl
+++ b/src/rebar_reltool.erl
@@ -67,7 +67,7 @@ generate(Config0, ReltoolFile) ->
 overlay(Config, ReltoolFile) ->
     %% Load the reltool configuration from the file
     {Config1, ReltoolConfig} = rebar_rel_utils:load_config(Config, ReltoolFile),
-    {Config1, process_overlay(Config, ReltoolConfig)}.
+    {process_overlay(Config, ReltoolConfig), Config1}.
 
 clean(Config, ReltoolFile) ->
     {Config1, ReltoolConfig} = rebar_rel_utils:load_config(Config, ReltoolFile),


### PR DESCRIPTION
- Bug fix: When rebar is called with overlay option the rebar_core
  got a wrong result {Config, ok} from rebar_reltool instead of {ok, Config}
