### PR TITLE
Add hostname variable to reltool overlay templates

### DIFF
--- a/src/rebar_reltool.erl
+++ b/src/rebar_reltool.erl
@@ -109,7 +109,8 @@ process_overlay(Config, ReltoolConfig) ->
     OverlayVars0 =
         dict:from_list([{erts_vsn, "erts-" ++ erlang:system_info(version)},
                         {rel_vsn, BootRelVsn},
-                        {target_dir, TargetDir}]),
+                        {target_dir, TargetDir},
+                        {hostname, net_adm:localhost()}]),
 
     %% Load up any variables specified by overlay_vars
     OverlayVars1 = overlay_vars(Config, OverlayVars0, ReltoolConfig),


### PR DESCRIPTION
- New feature: hostname variable added to facilitate macro substitutions
  in reltool overlay templates
