### PR TITLE
Fix erlydtl dependency check

### DIFF
--- a/src/rebar_erlydtl_compiler.erl
+++ b/src/rebar_erlydtl_compiler.erl
@@ -173,8 +173,8 @@ referenced_dtls1(Step, Config, Seen) ->
     AllRefs =
         lists:append(
           [begin
-               Cmd = lists:flatten(["grep -o [^\\\"]*",
-                                    ExtMatch, " ", F]),
+               Cmd = lists:flatten(["grep -o [^\\\"]*\\",
+                                    ExtMatch, "[^\\\"]* ", F]),
                case rebar_utils:sh(Cmd, ShOpts) of
                    {ok, Res} ->
                        string:tokens(Res, "\n");


### PR DESCRIPTION
When a DTL template includes other template files, those files don't need
to be compiled separately, and therefore can be given an extension different
from `source_ext` (such as `.dtli`) to avoid being compiled.  This fix
allows rebar to find included dependencies with names `*.dtl*` rather
than `*.dtl` and properly determine if a template file needs to be recompiled.
