### PR TITLE
Support environment vars with unicode characters

### DIFF
--- a/src/rebar_port_compiler.erl
+++ b/src/rebar_port_compiler.erl
@@ -472,7 +472,7 @@ erts_dir() ->
     lists:concat([code:root_dir(), "/erts-", erlang:system_info(version)]).
 
 os_env() ->
-    Os = [list_to_tuple(re:split(S, "=", [{return, list}, {parts, 2}])) ||
+    Os = [list_to_tuple(re:split(S, "=", [{return, list}, {parts, 2}, unicode])) ||
              S <- os:getenv()],
     %% Drop variables without a name (win32)
     [T1 || {K, _V} = T1 <- Os, K =/= []].


### PR DESCRIPTION
The results returned by os:getenv() may contain unicode characters.
That said, we need to explicitly allow unicode when splitting the
environment information, otherwise badarg will be raised causing all
rebar commands to fail until the environment variable is removed.

See https://gist.github.com/3804283
