### PR TITLE
Add config support for protobuffs

### DIFF
--- a/src/rebar_protobuffs_compiler.erl
+++ b/src/rebar_protobuffs_compiler.erl
@@ -102,8 +102,9 @@ compile_each(Config, [{Proto, Beam, Hrl} | Rest]) ->
         true ->
             ?CONSOLE("Compiling ~s\n", [Proto]),
             ErlOpts = rebar_utils:erl_opts(Config),
-            case protobuffs_compile:scan_file(Proto,
-                                              [{compile_flags,ErlOpts}]) of
+            ProtobuffOpts = rebar_config:get(Config, protobuff_opts,
+                                             [{compile_flags, ErlOpts}]),
+            case protobuffs_compile:scan_file(Proto, ProtobuffOpts) of
                 ok ->
                     %% Compilation worked, but we need to move the
                     %% beam and .hrl file into the ebin/ and include/


### PR DESCRIPTION
The current protobuffs config only copy "erl_opts" to
"compile_flags". Some other configs such as "imports_dir" is very
importent, too.
