### PR TITLE
fix erlydtl 0.8 compilation

### DIFF
--- a/src/rebar_erlydtl_compiler.erl
+++ b/src/rebar_erlydtl_compiler.erl
@@ -210,6 +210,8 @@ do_compile(Config, Source, Target, DtlOpts) ->
                          Opts) of
         ok ->
             ok;
+        {ok, _Module} ->
+            ok;
         error ->
             rebar_base_compiler:error_tuple(Config, Source, [], [], Opts);
         {error, {_File, _Msgs} = Error} ->


### PR DESCRIPTION
Currently erlydtl 0.8+ compilation is broken and raises the following errors:

```
unexpected error compiling templates/profile.html
{'EXIT',{{case_clause,{ok,profile_dtl}},
         [{rebar_erlydtl_compiler,do_compile,4,
                                  [{file,"src/rebar_erlydtl_compiler.erl"},
                                   {line,208}]},
          {rebar_base_compiler,compile,3,
                               [{file,"src/rebar_base_compiler.erl"},
                                {line,121}]},
          {rebar_base_compiler,compile_worker,3,
                               [{file,"src/rebar_base_compiler.erl"},
                                {line,194}]}]}}
ERROR: compile failed while processing /Users/dialtone/dev/Adroll/dyno: rebar_abort
make: *** [all] Error 1
```

With this simple pull request you can compile erlydtl templates again.
